### PR TITLE
[BE]: 이슈 CRUD 기능 구현

### DIFF
--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/IssueController.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/IssueController.java
@@ -1,9 +1,14 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller;
 
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.request.IssueStatusRequest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.response.ApiResponse;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.response.FilterResponse;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.IssueService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -20,5 +25,11 @@ public class IssueController {
     @GetMapping("/api/issues/closed")
     public FilterResponse readCloseIssues() {
         return FilterResponse.from(issueService.readClosedIssues());
+    }
+
+    @PatchMapping("/api/issues")
+    public ApiResponse updateIssueStatus(@RequestBody IssueStatusRequest request) {
+        issueService.updateIssueStatus(IssueStatusRequest.to(request));
+        return ApiResponse.success(HttpStatus.OK);
     }
 }

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/request/IssueStatusRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/request/IssueStatusRequest.java
@@ -1,0 +1,26 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.request;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.condition.IssueStatusCondition;
+import java.util.List;
+import lombok.Getter;
+
+
+@Getter
+public class IssueStatusRequest {
+
+    private final boolean isOpen;
+    private final List<Long> issues;
+
+
+    private IssueStatusRequest(boolean isOpen, List<Long> issues) {
+        this.isOpen = isOpen;
+        this.issues = issues;
+    }
+
+    public static IssueStatusCondition to(IssueStatusRequest request) {
+        return IssueStatusCondition.builder()
+                .isOpen(request.isOpen)
+                .issueIds(request.getIssues())
+                .build();
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/request/IssueStatusRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/request/IssueStatusRequest.java
@@ -2,6 +2,7 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.request;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.condition.IssueStatusCondition;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 
 
@@ -12,6 +13,7 @@ public class IssueStatusRequest {
     private final List<Long> issues;
 
 
+    @Builder
     private IssueStatusRequest(boolean isOpen, List<Long> issues) {
         this.isOpen = isOpen;
         this.issues = issues;

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/ApiResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/ApiResponse.java
@@ -1,0 +1,18 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ApiResponse {
+
+    private final int statusCode;
+
+    public ApiResponse(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public static ApiResponse success(HttpStatus status) {
+        return new ApiResponse(status.value());
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepository.java
@@ -1,8 +1,10 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository;
 
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.vo.IssueStatusVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.vo.IssueVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -48,6 +50,15 @@ public class IssueRepository {
                 "ORDER BY i.id DESC";
 
         return template.query(sql, issueVOMapper);
+    }
+
+    public void updateIssuesStatus(IssueStatusVO vo) {
+        String sql = "UPDATE issue SET is_open = :is_open WHERE id IN (:issueIds)";
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("is_open", vo.isOpen())
+                .addValue("issueIds", vo.getIssueIds());
+        template.update(sql, params);
     }
 
     private final RowMapper<IssueVO> issueVOMapper = (rs, rowNum) -> IssueVO.builder()

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/vo/IssueStatusVO.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/vo/IssueStatusVO.java
@@ -1,0 +1,18 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.vo;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class IssueStatusVO {
+
+    private final boolean isOpen;
+    private final List<Long> issueIds;
+
+    @Builder
+    private IssueStatusVO(boolean isOpen, List<Long> issueIds) {
+        this.isOpen = isOpen;
+        this.issueIds = issueIds;
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/IssueService.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/IssueService.java
@@ -2,6 +2,7 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.IssueRepository;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.vo.IssueVO;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.condition.IssueStatusCondition;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.FilterInformation;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.LabelRepository;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelVO;
@@ -42,6 +43,10 @@ public class IssueService {
         Map<Long, List<String>> assigneeProfiles = memberRepository.findAllProfilesByIssueIds(issueIds);
 
         return FilterInformation.from(statVO, issueVOs, labelVOs, assigneeProfiles);
+    }
+
+    public void updateIssueStatus(IssueStatusCondition condition) {
+        issueRepository.updateIssuesStatus(IssueStatusCondition.to(condition));
     }
 
     private List<Long> getIssueIds(List<IssueVO> issueVOs) {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/condition/IssueStatusCondition.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/condition/IssueStatusCondition.java
@@ -1,0 +1,26 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.condition;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.vo.IssueStatusVO;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class IssueStatusCondition {
+
+    private final boolean isOpen;
+    private final List<Long> issueIds;
+
+    @Builder
+    private IssueStatusCondition(boolean isOpen, List<Long> issueIds) {
+        this.isOpen = isOpen;
+        this.issueIds = issueIds;
+    }
+
+    public static IssueStatusVO to(IssueStatusCondition condition) {
+        return IssueStatusVO.builder()
+                .isOpen(condition.isOpen)
+                .issueIds(condition.getIssueIds())
+                .build();
+    }
+}

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/integration/IssueIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/integration/IssueIntegrationTest.java
@@ -1,13 +1,19 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.integration;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.IntegrationTest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.request.IssueStatusRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,6 +23,9 @@ public class IssueIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
 
     @DisplayName("열린 이슈의 모든 정보를 다 가지고 온다.")
     @Test
@@ -48,5 +57,26 @@ public class IssueIntegrationTest {
                 .andExpect(jsonPath("$.issues.[0].assigneeProfiles.length()").value(0))
                 .andExpect(jsonPath("$.issues.[1].labels.[0].name").value("라벨 1"))
                 .andDo(print());
+    }
+
+    @DisplayName("선택한 이슈의 상태를 변경한다.")
+    @Test
+    void testUpdateIssueStatusIntegrationTest() throws Exception {
+
+        IssueStatusRequest request = IssueStatusRequest.builder()
+                .isOpen(false)
+                .issues(List.of(4L,5L))
+                .build();
+
+        ResultActions resultActions = mockMvc.perform(patch("/api/issues")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)));
+
+        resultActions.andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    private <T> String toJson(T data) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(data);
     }
 }


### PR DESCRIPTION
<!-- 피알 제목 예시입니다. -->
<!-- [BE]: 회원 가입 기능 추가 (#14) -->

### 구현 내용

선택한 이슈 상태 변경하기 기능을 구현했습니다.
이슈 작성기능을 구현했습니다.
<!-- 전체적인 구현 내용을 적어주세요 -->
<!-- 예시: 회원 가입 기능을 만들었습니다. -->

### 상세 내용

- 선택한 이슈 id를 전달받아서 db에 이슈 상태를 isOpen 필드 값으로 변경
- ApiResponse를 통해 상태코드 반환
<!-- 구현 내용의 상세 내용을 적어주세요 -->
<!-- 예시: 
- 패스워드 암호화 저장
- 아이디 길이 검증
- 아이디 중복 검증
- 회원 가입 테스트 코드 작성
-->
