### PR TITLE
[BE]: 리뷰 적용하여 리팩토링 (#53)

### DIFF
--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/AssigneeFilterResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/AssigneeFilterResponse.java
@@ -1,10 +1,11 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.response;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.AssigneeFilterInformation;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class AssigneeFilterResponse {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/AuthorFilterResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/AuthorFilterResponse.java
@@ -1,10 +1,11 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.response;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.AuthorFilterInformation;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class AuthorFilterResponse {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/FilterListResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/FilterListResponse.java
@@ -3,9 +3,10 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.response
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.FilterListInformation;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class FilterListResponse {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/LabelFilterResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/LabelFilterResponse.java
@@ -1,10 +1,11 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.response;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.LabelFilterInformation;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class LabelFilterResponse {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/MilestoneFilterResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/MilestoneFilterResponse.java
@@ -3,10 +3,11 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.response
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.MilestoneFilterInformation;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class MilestoneFilterResponse {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepository.java
@@ -1,6 +1,7 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.vo.IssueVO;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -10,15 +11,11 @@ import javax.sql.DataSource;
 import java.util.List;
 
 
+@RequiredArgsConstructor
 @Repository
 public class IssueRepository {
 
     private final NamedParameterJdbcTemplate template;
-
-    @Autowired
-    public IssueRepository(DataSource dataSource) {
-        this.template = new NamedParameterJdbcTemplate(dataSource);
-    }
 
     public List<IssueVO> findOpenIssues() {
         String sql = "SELECT issue.id, " +

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepository.java
@@ -2,20 +2,24 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.vo.IssueVO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import javax.sql.DataSource;
 import java.util.List;
-
 
 @RequiredArgsConstructor
 @Repository
 public class IssueRepository {
 
     private final NamedParameterJdbcTemplate template;
+    private final RowMapper<IssueVO> issueVOMapper = (rs, rowNum) -> IssueVO.builder()
+            .id(rs.getLong("id"))
+            .author(rs.getString("author_name"))
+            .milestone(rs.getString("milestone_name"))
+            .title(rs.getString("title"))
+            .createdAt(rs.getTimestamp("created_at").toLocalDateTime())
+            .build();
 
     public List<IssueVO> findOpenIssues() {
         String sql = "SELECT issue.id, " +
@@ -46,12 +50,4 @@ public class IssueRepository {
 
         return template.query(sql, issueVOMapper);
     }
-
-    private final RowMapper<IssueVO> issueVOMapper = (rs, rowNum) -> IssueVO.builder()
-            .id(rs.getLong("id"))
-            .author(rs.getString("author_name"))
-            .milestone(rs.getString("milestone_name"))
-            .title(rs.getString("title"))
-            .createdAt(rs.getTimestamp("created_at").toLocalDateTime())
-            .build();
 }

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/information/AssigneeFilterInformation.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/information/AssigneeFilterInformation.java
@@ -1,12 +1,13 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository.vo.MemberDetailsVO;
+import lombok.Builder;
+import lombok.Getter;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.Builder;
-import lombok.Getter;
 
 @Getter
 public class AssigneeFilterInformation {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/information/AuthorFilterInformation.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/information/AuthorFilterInformation.java
@@ -1,10 +1,11 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository.vo.MemberDetailsVO;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class AuthorFilterInformation {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/information/FilterListInformation.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/information/FilterListInformation.java
@@ -4,11 +4,12 @@ import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.Label
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository.vo.MemberDetailsVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.vo.MilestoneDetailsVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
+import lombok.Builder;
+import lombok.Getter;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import lombok.Builder;
-import lombok.Getter;
 
 @Getter
 public class FilterListInformation {
@@ -20,9 +21,9 @@ public class FilterListInformation {
 
     @Builder
     private FilterListInformation(List<AssigneeFilterInformation> assigneeFilterInformations,
-                                 List<AuthorFilterInformation> authorFilterInformations,
-                                 List<LabelFilterInformation> labelFilterInformations,
-                                 List<MilestoneFilterInformation> milestoneFilterInformations) {
+                                  List<AuthorFilterInformation> authorFilterInformations,
+                                  List<LabelFilterInformation> labelFilterInformations,
+                                  List<MilestoneFilterInformation> milestoneFilterInformations) {
         this.assigneeFilterInformations = assigneeFilterInformations;
         this.authorFilterInformations = authorFilterInformations;
         this.labelFilterInformations = labelFilterInformations;
@@ -37,7 +38,6 @@ public class FilterListInformation {
                 .labelFilterInformations(LabelFilterInformation.from(labels))
                 .milestoneFilterInformations(MilestoneFilterInformation.from(milestones))
                 .build();
-
     }
 
     public static FilterListInformation from(List<MemberDetailsVO> assignees, List<LabelDetailsVO> labels,

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/information/LabelFilterInformation.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/information/LabelFilterInformation.java
@@ -1,10 +1,11 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelDetailsVO;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class LabelFilterInformation {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/information/MilestoneFilterInformation.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/information/MilestoneFilterInformation.java
@@ -2,11 +2,12 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.informatio
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.vo.MilestoneDetailsVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
+import lombok.Builder;
+import lombok.Getter;
+
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.Builder;
-import lombok.Getter;
 
 @Getter
 public class MilestoneFilterInformation {
@@ -38,7 +39,7 @@ public class MilestoneFilterInformation {
     }
 
     public static List<MilestoneFilterInformation> from(List<MilestoneDetailsVO> milestoneDetailsVOs,
-                                                  Map<Long, IssueByMilestoneVO> issuesCountByMilestoneIds) {
+                                                        Map<Long, IssueByMilestoneVO> issuesCountByMilestoneIds) {
         return milestoneDetailsVOs.stream()
                 .map(milestoneDetailsVO -> from(milestoneDetailsVO, issuesCountByMilestoneIds))
                 .collect(Collectors.toUnmodifiableList());

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/controller/response/LabelDetailsResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/controller/response/LabelDetailsResponse.java
@@ -1,10 +1,11 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.label.controller.response;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.information.LabelDetailsInformation;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class LabelDetailsResponse {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/controller/response/LabelPageResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/controller/response/LabelPageResponse.java
@@ -2,9 +2,10 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.label.controller.respons
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.information.LabelPageInformation;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class LabelPageResponse {
@@ -16,7 +17,7 @@ public class LabelPageResponse {
 
     @Builder
     private LabelPageResponse(Integer milestoneCount, Integer labelCount,
-                             List<LabelDetailsResponse> labelDetailsResponses) {
+                              List<LabelDetailsResponse> labelDetailsResponses) {
         this.milestoneCount = milestoneCount;
         this.labelCount = labelCount;
         this.labelDetailsResponses = labelDetailsResponses;

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepository.java
@@ -3,13 +3,11 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelDetailsVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelVO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import javax.sql.DataSource;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -72,7 +70,7 @@ public class LabelRepository {
                 .build());
     }
 
-    private final RowMapper<LabelDetailsVO> labelSimpleVORowMapper(){
+    private final RowMapper<LabelDetailsVO> labelSimpleVORowMapper() {
         return ((rs, rowNum) -> LabelDetailsVO.builder()
                 .id(rs.getLong("id"))
                 .name(rs.getString("name"))

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepository.java
@@ -2,6 +2,7 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelDetailsVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelVO;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -13,15 +14,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@RequiredArgsConstructor
 @Repository
 public class LabelRepository {
 
     private final NamedParameterJdbcTemplate template;
-
-    @Autowired
-    public LabelRepository(DataSource dataSource) {
-        this.template = new NamedParameterJdbcTemplate(dataSource);
-    }
 
     public Map<Long, List<LabelVO>> findAllByIssueIds(List<Long> issueIds) {
         return issueIds.stream()

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/service/LabelService.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/service/LabelService.java
@@ -5,9 +5,10 @@ import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.Label
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.information.LabelPageInformation;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.StatRepository;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.StatVO;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/service/information/LabelDetailsInformation.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/service/information/LabelDetailsInformation.java
@@ -1,10 +1,11 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.information;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelDetailsVO;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class LabelDetailsInformation {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/service/information/LabelPageInformation.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/service/information/LabelPageInformation.java
@@ -2,9 +2,10 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.informatio
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelDetailsVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.StatVO;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class LabelPageInformation {
@@ -15,7 +16,7 @@ public class LabelPageInformation {
 
     @Builder
     private LabelPageInformation(Integer milestoneCount, Integer labelCount,
-                                List<LabelDetailsInformation> labelDetailsInformations) {
+                                 List<LabelDetailsInformation> labelDetailsInformations) {
         this.milestoneCount = milestoneCount;
         this.labelCount = labelCount;
         this.labelDetailsInformations = labelDetailsInformations;

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/repository/MemberRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository.vo.MemberDetailsVO;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -12,15 +13,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@RequiredArgsConstructor
 @Repository
 public class MemberRepository {
 
     private final NamedParameterJdbcTemplate template;
-
-    @Autowired
-    public MemberRepository(DataSource dataSource) {
-        this.template = new NamedParameterJdbcTemplate(dataSource);
-    }
 
     public Map<Long, List<String>> findAllProfilesByIssueIds(List<Long> issueIds ) {
         return issueIds.stream()

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/repository/MemberRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/repository/MemberRepository.java
@@ -2,13 +2,11 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository.vo.MemberDetailsVO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import javax.sql.DataSource;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -19,7 +17,7 @@ public class MemberRepository {
 
     private final NamedParameterJdbcTemplate template;
 
-    public Map<Long, List<String>> findAllProfilesByIssueIds(List<Long> issueIds ) {
+    public Map<Long, List<String>> findAllProfilesByIssueIds(List<Long> issueIds) {
         return issueIds.stream()
                 .collect(Collectors.toUnmodifiableMap(
                         issueId -> issueId,
@@ -29,9 +27,9 @@ public class MemberRepository {
 
     public List<String> findAllProfilesByIssueId(Long issueId) {
         String sql = "SELECT member.profile " +
-                    "FROM member " +
-                    "JOIN issue_assignee ON member.id = issue_assignee.assignee_id " +
-                    "WHERE issue_assignee.issue_id = :issueId";
+                "FROM member " +
+                "JOIN issue_assignee ON member.id = issue_assignee.assignee_id " +
+                "WHERE issue_assignee.issue_id = :issueId";
 
         return template.queryForList(sql, Map.of("issueId", issueId), String.class);
     }

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/response/MilestoneDetailsResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/response/MilestoneDetailsResponse.java
@@ -1,11 +1,12 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.controller.response;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.information.MilestoneDetailsInformation;
+import lombok.Builder;
+import lombok.Getter;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.Builder;
-import lombok.Getter;
 
 @Getter
 public class MilestoneDetailsResponse {
@@ -19,7 +20,7 @@ public class MilestoneDetailsResponse {
 
     @Builder
     private MilestoneDetailsResponse(Long id, String name, String description, LocalDate dueDate, Integer openIssueCount,
-                                    Integer closedIssuesCount) {
+                                     Integer closedIssuesCount) {
         this.id = id;
         this.name = name;
         this.description = description;

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/response/MilestonePageResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/response/MilestonePageResponse.java
@@ -1,11 +1,11 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.controller.response;
 
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.information.MilestoneDetailsInformation;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.information.MilestonePageInformation;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class MilestonePageResponse {
@@ -18,7 +18,7 @@ public class MilestonePageResponse {
 
     @Builder
     private MilestonePageResponse(Integer openMilestoneCount, Integer closeMilestoneCount, Integer labelCount,
-                                 List<MilestoneDetailsResponse> milestoneDetailsResponses) {
+                                  List<MilestoneDetailsResponse> milestoneDetailsResponses) {
         this.openMilestoneCount = openMilestoneCount;
         this.closeMilestoneCount = closeMilestoneCount;
         this.labelCount = labelCount;

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/MilestoneRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/MilestoneRepository.java
@@ -1,15 +1,13 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.vo.MilestoneDetailsVO;
-import java.util.List;
-import javax.sql.DataSource;
-
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Repository

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/MilestoneRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/MilestoneRepository.java
@@ -3,21 +3,19 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.vo.MilestoneDetailsVO;
 import java.util.List;
 import javax.sql.DataSource;
+
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+@RequiredArgsConstructor
 @Repository
 public class MilestoneRepository {
 
     private final NamedParameterJdbcTemplate template;
-
-    @Autowired
-    public MilestoneRepository(DataSource dataSource) {
-        this.template = new NamedParameterJdbcTemplate(dataSource);
-    }
 
     public List<MilestoneDetailsVO> findOpenMilestones() {
         String sql = "SELECT id, name, description, due_date " +

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/vo/MilestoneDetailsVO.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/vo/MilestoneDetailsVO.java
@@ -1,8 +1,9 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.vo;
 
-import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDate;
 
 @Getter
 public class MilestoneDetailsVO {
@@ -16,7 +17,7 @@ public class MilestoneDetailsVO {
 
     @Builder
     private MilestoneDetailsVO(Long id, String name, String description, LocalDate dueDate, Integer openIssueCount,
-                              Integer closedIssuesCount) {
+                               Integer closedIssuesCount) {
         this.id = id;
         this.name = name;
         this.description = description;

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/service/MilestoneService.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/service/MilestoneService.java
@@ -1,16 +1,17 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.MilestoneRepository;
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.vo.MilestoneDetailsVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.information.MilestonePageInformation;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.StatRepository;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.MilestoneStatVO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/service/information/MilestoneDetailsInformation.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/service/information/MilestoneDetailsInformation.java
@@ -1,13 +1,14 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.information;
 
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.vo.MilestoneDetailsVO;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
+import lombok.Builder;
+import lombok.Getter;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.Builder;
-import lombok.Getter;
 
 @Getter
 public class MilestoneDetailsInformation {
@@ -21,7 +22,7 @@ public class MilestoneDetailsInformation {
 
     @Builder
     private MilestoneDetailsInformation(Long id, String name, String description, LocalDate dueDate,
-                                       Integer openIssueCount, Integer closedIssuesCount) {
+                                        Integer openIssueCount, Integer closedIssuesCount) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -47,6 +48,5 @@ public class MilestoneDetailsInformation {
                 .openIssueCount(issueByMilestoneVOs.get(milestoneDetailsVO.getId()).getOpenIssueCount())
                 .closedIssuesCount(issueByMilestoneVOs.get(milestoneDetailsVO.getId()).getClosedIssueCount())
                 .build();
-
     }
 }

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/service/information/MilestonePageInformation.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/service/information/MilestonePageInformation.java
@@ -1,12 +1,13 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.information;
 
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.vo.MilestoneDetailsVO;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.MilestoneStatVO;
-import java.util.List;
-import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
 
 @Getter
 public class MilestonePageInformation {
@@ -18,7 +19,7 @@ public class MilestonePageInformation {
 
     @Builder
     private MilestonePageInformation(Integer openMilestoneCount, Integer closeMilestoneCount, Integer labelCount,
-                                    List<MilestoneDetailsInformation> milestoneDetailsInformations) {
+                                     List<MilestoneDetailsInformation> milestoneDetailsInformations) {
         this.openMilestoneCount = openMilestoneCount;
         this.closeMilestoneCount = closeMilestoneCount;
         this.labelCount = labelCount;

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/stat/repository/StatRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/stat/repository/StatRepository.java
@@ -3,25 +3,28 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.MilestoneStatVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.StatVO;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
-import javax.sql.DataSource;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Repository
 public class StatRepository {
 
     private final NamedParameterJdbcTemplate template;
+    private final RowMapper<StatVO> statVORowMapper = (rs, rowNum) -> StatVO.builder()
+            .openIssueCount(rs.getInt("open_issue_count"))
+            .closedIssueCount(rs.getInt("closed_issue_count"))
+            .milestoneCount((rs.getInt("milestone_count")))
+            .labelCount(rs.getInt("label_count"))
+            .build();
 
     public StatVO countOverallStats() {
         String sql = "SELECT " +
@@ -67,13 +70,6 @@ public class StatRepository {
 
         return template.queryForObject(sql, Map.of("milestoneId", milestoneId), issueByMilestoneVORowMapper());
     }
-
-    private final RowMapper<StatVO> statVORowMapper = (rs, rowNum) -> StatVO.builder()
-            .openIssueCount(rs.getInt("open_issue_count"))
-            .closedIssueCount(rs.getInt("closed_issue_count"))
-            .milestoneCount((rs.getInt("milestone_count")))
-            .labelCount(rs.getInt("label_count"))
-            .build();
 
     private final RowMapper<StatVO> countLabelStatsRowMapper() {
         return ((rs, rowNum) -> StatVO.builder()

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/stat/repository/StatRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/stat/repository/StatRepository.java
@@ -6,6 +6,8 @@ import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.StatVO
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -15,15 +17,11 @@ import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
 
+@RequiredArgsConstructor
 @Repository
 public class StatRepository {
 
     private final NamedParameterJdbcTemplate template;
-
-    @Autowired
-    public StatRepository(DataSource dataSource) {
-        this.template = new NamedParameterJdbcTemplate(dataSource);
-    }
 
     public StatVO countOverallStats() {
         String sql = "SELECT " +

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -4,11 +4,9 @@ spring:
     username: user
     password: admin
     driver-class-name: com.mysql.cj.jdbc.Driver
+
   sql:
     init:
       mode: always
       schema-locations: classpath*:schema.sql
     encoding: UTF-8
-  jpa:
-    hibernate:
-    ddl-auto: none

--- a/be/src/main/resources/data.sql
+++ b/be/src/main/resources/data.sql
@@ -1,7 +1,10 @@
 INSERT INTO member (email, name, password, profile)
-values ('nag@codesquad.kr', 'nag', '1q2w3e4r!', 'https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png'),
-       ('joy@codesquad.kr', 'joy', '1q2w3e4r!', 'https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png'),
-       ('ati@codesquad.kr', 'ati', '1q2w3e4r!', 'https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png');
+values ('nag@codesquad.kr', 'nag', '1q2w3e4r!',
+        'https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png'),
+       ('joy@codesquad.kr', 'joy', '1q2w3e4r!',
+        'https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png'),
+       ('ati@codesquad.kr', 'ati', '1q2w3e4r!',
+        'https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png');
 
 INSERT INTO milestone (name, due_date, is_open)
 values ('마일스톤 1', current_date, 1),
@@ -42,7 +45,7 @@ values (1, 1),
        (4, 2),
        (4, 3);
 
-INSERT INTO  comment (issue_id, author_id, contents)
+INSERT INTO comment (issue_id, author_id, contents)
 values (1, 1, '1번 댓글입니다.'),
        (1, 2, '2번 댓글입니다.'),
        (1, 2, '3번 댓글입니다.'),

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/annotation/RepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/annotation/RepositoryTest.java
@@ -1,15 +1,13 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.annotation;
 
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.test.context.jdbc.Sql;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.jdbc.Sql;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/annotation/ServiceTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/annotation/ServiceTest.java
@@ -12,4 +12,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(MockitoExtension.class)
 public @interface ServiceTest {
+
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/controller/IssueControllerTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/controller/IssueControllerTest.java
@@ -30,78 +30,95 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @ControllerTest(IssueController.class)
-public class IssueControllerTest {
+class IssueControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
     @MockBean
     private IssueService issueService;
 
     @DisplayName("열린 이슈에 관한 FilterInformation을 FilterResponse로 변환한다.")
     @Test
     void readOpenIssuesTest() throws Exception {
+        //given
         given(issueService.readOpenIssues()).willReturn(createDummyFilterInformation());
 
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/issues/open"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.openIssueCount").value(3))
-                .andExpect(jsonPath("$.milestoneCount").value(2))
-                .andExpect(jsonPath("$.issues.length()").value(3))
-                .andExpect(jsonPath("$.issues.[1].title").value("제목 2"))
-                .andExpect(jsonPath("$.issues.[2].labels.length()").value(0))
-                .andDo(print());
+                .andExpectAll(
+                        jsonPath("$.openIssueCount").value(3),
+                        jsonPath("$.milestoneCount").value(2),
+                        jsonPath("$.issues.length()").value(3),
+                        jsonPath("$.issues.[1].title").value("제목 2"),
+                        jsonPath("$.issues.[2].labels.length()").value(0)
+                );
     }
 
     @DisplayName("닫힌 이슈에 관한 FilterInformation을 FilterResponse로 변환한다.")
     @Test
     void readClosedIssuesTest() throws Exception {
+        //given
         given(issueService.readClosedIssues()).willReturn(createDummyFilterInformation());
 
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/issues/closed"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.closedIssueCount").value(3))
-                .andExpect(jsonPath("$.labelCount").value(4))
-                .andExpect(jsonPath("$.issues.length()").value(3))
-                .andExpect(jsonPath("$.issues.[0].author").value("작성자 1"))
-                .andExpect(jsonPath("$.issues.[1].assigneeProfiles.[0]").value("담당자 3"))
-                .andDo(print());
+                .andExpectAll(
+                        jsonPath("$.closedIssueCount").value(3),
+                        jsonPath("$.labelCount").value(4),
+                        jsonPath("$.issues.length()").value(3),
+                        jsonPath("$.issues.[0].author").value("작성자 1"),
+                        jsonPath("$.issues.[1].assigneeProfiles.[0]").value("담당자 3")
+                );
     }
 
     @DisplayName("메인 화면의 필터 내용을 담은 FilterListInformation을 FilterListResponse으로 변환한다.")
     @Test
     void testReadFilters() throws Exception {
+        //given
         given(issueService.readFilters()).willReturn(createDummyFilterListInformation());
 
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/filters"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.assignees.length()").value(3))
-                .andExpect(jsonPath("$.authors.length()").value(2))
-                .andExpect(jsonPath("$.authors.[0].name").value("a"))
-                .andExpect(jsonPath("$.labels.length()").value(1))
-                .andExpect(jsonPath("$.milestones.length()").value(0))
-                .andDo(print());
+                .andExpectAll(
+                        jsonPath("$.assignees.length()").value(3),
+                        jsonPath("$.authors.length()").value(2),
+                        jsonPath("$.authors.[0].name").value("a"),
+                        jsonPath("$.labels.length()").value(1),
+                        jsonPath("$.milestones.length()").value(0)
+                );
     }
 
     @DisplayName("이슈 화면의 필터 내용을 담은 FilterListInformation을 FilterListResponse으로 변환한다.")
     @Test
     void testReadFiltersFromIssue() throws Exception {
+        //given
         given(issueService.readFiltersFromIssue()).willReturn(createDummyFilterListInformationByIssue());
 
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/issues"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.assignees.length()").value(3))
-                .andExpect(jsonPath("$.authors.length()").value(0))
-                .andExpect(jsonPath("$.labels.length()").value(1))
-                .andExpect(jsonPath("$.milestones.length()").value(0))
-                .andDo(print());
+                .andExpectAll(
+                        jsonPath("$.assignees.length()").value(3),
+                        jsonPath("$.authors.length()").value(0),
+                        jsonPath("$.labels.length()").value(1),
+                        jsonPath("$.milestones.length()").value(0)
+                );
     }
 
     private FilterListInformation createDummyFilterListInformation() {
@@ -141,7 +158,7 @@ public class IssueControllerTest {
         return List.of(tmp1, tmp2, tmp3);
     }
 
-    private List<AuthorFilterInformation> createDummyAuthorFilterInformations(){
+    private List<AuthorFilterInformation> createDummyAuthorFilterInformations() {
         AuthorFilterInformation tmp1 = AuthorFilterInformation.builder()
                 .id(1L)
                 .name("a")
@@ -239,6 +256,6 @@ public class IssueControllerTest {
                 .textColor("글자색 5")
                 .build();
 
-        return List.of(labelInformation1,labelInformation2, labelInformation3, labelInformation4, labelInformation5);
+        return List.of(labelInformation1, labelInformation2, labelInformation3, labelInformation4, labelInformation5);
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/controller/IssueControllerTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/controller/IssueControllerTest.java
@@ -3,13 +3,7 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.controller;
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.ControllerTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.IssueController;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.IssueService;
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.AssigneeFilterInformation;
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.FilterInformation;
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.FilterListInformation;
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.IssueInformation;
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.LabelFilterInformation;
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.AuthorFilterInformation;
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.MilestoneFilterInformation;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.service.information.*;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.information.LabelInformation;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,10 +18,8 @@ import java.util.List;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 
 @ControllerTest(IssueController.class)
 class IssueControllerTest {
@@ -40,7 +32,7 @@ class IssueControllerTest {
 
     @DisplayName("열린 이슈에 관한 FilterInformation을 FilterResponse로 변환한다.")
     @Test
-    void readOpenIssuesTest() throws Exception {
+    void readOpenIssues() throws Exception {
         //given
         given(issueService.readOpenIssues()).willReturn(createDummyFilterInformation());
 
@@ -61,7 +53,7 @@ class IssueControllerTest {
 
     @DisplayName("닫힌 이슈에 관한 FilterInformation을 FilterResponse로 변환한다.")
     @Test
-    void readClosedIssuesTest() throws Exception {
+    void readClosedIssues() throws Exception {
         //given
         given(issueService.readClosedIssues()).willReturn(createDummyFilterInformation());
 
@@ -82,7 +74,7 @@ class IssueControllerTest {
 
     @DisplayName("메인 화면의 필터 내용을 담은 FilterListInformation을 FilterListResponse으로 변환한다.")
     @Test
-    void testReadFilters() throws Exception {
+    void readFilters() throws Exception {
         //given
         given(issueService.readFilters()).willReturn(createDummyFilterListInformation());
 
@@ -103,7 +95,7 @@ class IssueControllerTest {
 
     @DisplayName("이슈 화면의 필터 내용을 담은 FilterListInformation을 FilterListResponse으로 변환한다.")
     @Test
-    void testReadFiltersFromIssue() throws Exception {
+    void readFiltersFromIssue() throws Exception {
         //given
         given(issueService.readFiltersFromIssue()).willReturn(createDummyFilterListInformationByIssue());
 

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/integration/IssueIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/integration/IssueIntegrationTest.java
@@ -13,7 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @IntegrationTest
-public class IssueIntegrationTest {
+class IssueIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -21,65 +21,77 @@ public class IssueIntegrationTest {
     @DisplayName("열린 이슈의 모든 정보를 다 가지고 온다.")
     @Test
     void openIssueIntegrationTest() throws Exception {
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/issues/open"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.openIssueCount").value(2))
-                .andExpect(jsonPath("$.milestoneCount").value(4))
-                .andExpect(jsonPath("$.issues.length()").value(2))
-                .andExpect(jsonPath("$.issues.[0].labels.[0].backgroundColor").value("#F08080"))
-                .andExpect(jsonPath("$.issues.[1].title").value("제목 1"))
-                .andExpect(jsonPath("$.issues.[1].assigneeProfiles.length()").value(2))
-                .andDo(print());
+                .andExpectAll(
+                        jsonPath("$.openIssueCount").value(2),
+                        jsonPath("$.milestoneCount").value(4),
+                        jsonPath("$.issues.length()").value(2),
+                        jsonPath("$.issues.[0].labels.[0].backgroundColor").value("#F08080"),
+                        jsonPath("$.issues.[1].title").value("제목 1"),
+                        jsonPath("$.issues.[1].assigneeProfiles.length()").value(2)
+                );
     }
 
     @DisplayName("닫힌 이슈의 모든 정보를 다 가지고 온다.")
     @Test
     void closedIssueIntegrationTest() throws Exception {
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/issues/closed"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.closedIssueCount").value(3))
-                .andExpect(jsonPath("$.labelCount").value(4))
-                .andExpect(jsonPath("$.issues.length()").value(3))
-                .andExpect(jsonPath("$.issues.[0].labels.length()").value(0))
-                .andExpect(jsonPath("$.issues.[0].assigneeProfiles.length()").value(0))
-                .andExpect(jsonPath("$.issues.[1].labels.[0].name").value("라벨 1"))
-                .andDo(print());
+                .andExpectAll(
+                        jsonPath("$.closedIssueCount").value(3),
+                        jsonPath("$.labelCount").value(4),
+                        jsonPath("$.issues.length()").value(3),
+                        jsonPath("$.issues.[0].labels.length()").value(0),
+                        jsonPath("$.issues.[0].assigneeProfiles.length()").value(0),
+                        jsonPath("$.issues.[1].labels.[0].name").value("라벨 1")
+                );
     }
 
     @DisplayName("메인 화면의 필터 목록을 가지고 온다.")
     @Test
     void testReadFilters() throws Exception {
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/filters"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.assignees.length()").value(4))
-                .andExpect(jsonPath("$.authors.length()").value(3))
-                .andExpect(jsonPath("$.labels.length()").value(4))
-                .andExpect(jsonPath("$.milestones.length()").value(4))
-                .andExpect(jsonPath("$.assignees.[0].name").value("담당자가 없는 이슈"))
-                .andDo(print());
+                .andExpectAll(
+                        jsonPath("$.assignees.length()").value(4),
+                        jsonPath("$.authors.length()").value(3),
+                        jsonPath("$.labels.length()").value(4),
+                        jsonPath("$.milestones.length()").value(4),
+                        jsonPath("$.assignees.[0].name").value("담당자가 없는 이슈")
+                );
     }
 
     @DisplayName("이슈 화면의 필터 목록을 가지고 온다.")
     @Test
     void testReadFiltersByIssue() throws Exception {
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/issues"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.assignees.length()").value(3))
-                .andExpect(jsonPath("$.authors.length()").value(0))
-                .andExpect(jsonPath("$.labels.length()").value(4))
-                .andExpect(jsonPath("$.milestones.length()").value(4))
-                .andExpect(jsonPath("$.milestones.[0].openIssueCount").value(0))
-                .andExpect(jsonPath("$.milestones.[0].closedIssueCount").value(0))
-                .andExpect(jsonPath("$.milestones.[1].openIssueCount").value(1))
-                .andExpect(jsonPath("$.milestones.[1].closedIssueCount").value(2))
-                .andDo(print());
+                .andExpectAll(
+                        jsonPath("$.assignees.length()").value(3),
+                        jsonPath("$.authors.length()").value(0),
+                        jsonPath("$.labels.length()").value(4),
+                        jsonPath("$.milestones.length()").value(4),
+                        jsonPath("$.milestones.[0].openIssueCount").value(0),
+                        jsonPath("$.milestones.[0].closedIssueCount").value(0),
+                        jsonPath("$.milestones.[1].openIssueCount").value(1),
+                        jsonPath("$.milestones.[1].closedIssueCount").value(2)
+                );
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/integration/IssueIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/integration/IssueIntegrationTest.java
@@ -8,7 +8,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -20,7 +19,7 @@ class IssueIntegrationTest {
 
     @DisplayName("열린 이슈의 모든 정보를 다 가지고 온다.")
     @Test
-    void openIssueIntegrationTest() throws Exception {
+    void getOpenIssues() throws Exception {
         //when
         ResultActions resultActions = mockMvc.perform(get("/api/issues/open"));
 
@@ -39,7 +38,7 @@ class IssueIntegrationTest {
 
     @DisplayName("닫힌 이슈의 모든 정보를 다 가지고 온다.")
     @Test
-    void closedIssueIntegrationTest() throws Exception {
+    void getClosedIssues() throws Exception {
         //when
         ResultActions resultActions = mockMvc.perform(get("/api/issues/closed"));
 
@@ -58,7 +57,7 @@ class IssueIntegrationTest {
 
     @DisplayName("메인 화면의 필터 목록을 가지고 온다.")
     @Test
-    void testReadFilters() throws Exception {
+    void getFilters() throws Exception {
         //when
         ResultActions resultActions = mockMvc.perform(get("/api/filters"));
 
@@ -76,7 +75,7 @@ class IssueIntegrationTest {
 
     @DisplayName("이슈 화면의 필터 목록을 가지고 온다.")
     @Test
-    void testReadFiltersByIssue() throws Exception {
+    void getFiltersByIssue() throws Exception {
         //when
         ResultActions resultActions = mockMvc.perform(get("/api/issues"));
 

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepositoryTest.java
@@ -5,6 +5,7 @@ import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.vo.Issue
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import javax.sql.DataSource;
 import java.util.List;
@@ -17,8 +18,8 @@ public class IssueRepositoryTest {
     private final IssueRepository repository;
 
     @Autowired
-    public IssueRepositoryTest(DataSource dataSource) {
-        this.repository = new IssueRepository(dataSource);
+    public IssueRepositoryTest(NamedParameterJdbcTemplate template) {
+        this.repository = new IssueRepository(template);
     }
 
     @DisplayName("DB에서 열린 이슈를 불러온다.")

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepositoryTest.java
@@ -7,39 +7,45 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
-import javax.sql.DataSource;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @RepositoryTest
-public class IssueRepositoryTest {
+class IssueRepositoryTest {
 
     private final IssueRepository repository;
 
     @Autowired
-    public IssueRepositoryTest(NamedParameterJdbcTemplate template) {
+    IssueRepositoryTest(NamedParameterJdbcTemplate template) {
         this.repository = new IssueRepository(template);
     }
 
     @DisplayName("DB에서 열린 이슈를 불러온다.")
     @Test
-    void openIssuetest() {
-        List<IssueVO> actualValue = repository.findOpenIssues();
+    void findOpenIssue() {
+        //when
+        List<IssueVO> actual = repository.findOpenIssues();
 
-        assertThat(actualValue.size()).isEqualTo(2);
-        assertThat(actualValue.get(1).getTitle()).isEqualTo("제목 1");
-        assertThat(actualValue.get(0).getAuthor()).isEqualTo("ati");
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual).hasSize(2);
+            assertions.assertThat(actual.get(1).getTitle()).isEqualTo("제목 1");
+            assertions.assertThat(actual.get(0).getAuthor()).isEqualTo("ati");
+        });
     }
 
     @DisplayName("DB에서 닫힌 이슈를 불러온다.")
     @Test
-    void closedIssuetest() {
+    void findClosedIssue() {
+        //when
         List<IssueVO> actualValue = repository.findClosedIssues();
 
-        assertThat(actualValue.size()).isEqualTo(3);
-        assertThat(actualValue.get(0).getId()).isEqualTo(5);
-        assertThat(actualValue.get(2).getMilestone()).isEqualTo("마일스톤 2");
-
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actualValue.size()).isEqualTo(3);
+            assertions.assertThat(actualValue.get(0).getId()).isEqualTo(5);
+            assertions.assertThat(actualValue.get(2).getMilestone()).isEqualTo("마일스톤 2");
+        });
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/controller/LabelControllerTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/controller/LabelControllerTest.java
@@ -8,7 +8,9 @@ import codesquad.kr.gyeonggidoidle.issuetracker.annotation.ControllerTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.LabelService;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.information.LabelDetailsInformation;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.information.LabelPageInformation;
+
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,10 +23,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @ControllerTest(LabelController.class)
-public class LabelControllerTest {
+class LabelControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
     @MockBean
     private LabelService labelService;
 
@@ -37,10 +40,12 @@ public class LabelControllerTest {
 
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.milestoneCount").value(10))
-                .andExpect(jsonPath("$.labels.length()").value(2))
-                .andExpect(jsonPath("$.labels.[0].name").value("feat"))
-                .andExpect(jsonPath("$.labels.[1].textColor").value("##"));
+                .andExpectAll(
+                        jsonPath("$.milestoneCount").value(10),
+                        jsonPath("$.labels.length()").value(2),
+                        jsonPath("$.labels.[0].name").value("feat"),
+                        jsonPath("$.labels.[1].textColor").value("##")
+                );
 
     }
 
@@ -69,5 +74,4 @@ public class LabelControllerTest {
                 .build();
         return List.of(tmp1, tmp2);
     }
-
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/controller/LabelControllerTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/controller/LabelControllerTest.java
@@ -1,16 +1,9 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.label.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.ControllerTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.LabelService;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.information.LabelDetailsInformation;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.information.LabelPageInformation;
-
-import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,9 +11,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 
 @ControllerTest(LabelController.class)
 class LabelControllerTest {
@@ -33,11 +29,14 @@ class LabelControllerTest {
 
     @DisplayName("라벨 관리페이지 정보를 담은 LabelPageInformation을 LabelPageResponse으로 변환한다.")
     @Test
-    void testReadLabelPage() throws Exception {
+    void transformLabelPageInformation() throws Exception {
+        //given
         given(labelService.readLabelPage()).willReturn(createDummyLabelPageInformation());
 
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/labels"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
                 .andExpectAll(
@@ -46,7 +45,6 @@ class LabelControllerTest {
                         jsonPath("$.labels.[0].name").value("feat"),
                         jsonPath("$.labels.[1].textColor").value("##")
                 );
-
     }
 
     private LabelPageInformation createDummyLabelPageInformation() {

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/integration/LabelIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/integration/LabelIntegrationTest.java
@@ -1,17 +1,15 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.label.integration;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @IntegrationTest
 class LabelIntegrationTest {
@@ -21,9 +19,11 @@ class LabelIntegrationTest {
 
     @DisplayName("라벨의 모드 정보를 가지고 온다.")
     @Test
-    void testReadLabelPage() throws Exception {
+    void getLabels() throws Exception {
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/labels"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
                 .andExpectAll(

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/integration/LabelIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/integration/LabelIntegrationTest.java
@@ -14,7 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @IntegrationTest
-public class LabelIntegrationTest {
+class LabelIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -26,10 +26,11 @@ public class LabelIntegrationTest {
 
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.milestoneCount").value(4))
-                .andExpect(jsonPath("$.labelCount").value(4))
-                .andExpect(jsonPath("$.labels.length()").value(4))
-                .andExpect(jsonPath("$.labels.[0].name").value("라벨 0"))
-                .andDo(print());
+                .andExpectAll(
+                        jsonPath("$.milestoneCount").value(4),
+                        jsonPath("$.labelCount").value(4),
+                        jsonPath("$.labels.length()").value(4),
+                        jsonPath("$.labels.[0].name").value("라벨 0")
+                );
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepositoryTest.java
@@ -6,6 +6,7 @@ import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.Label
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import javax.sql.DataSource;
 import java.util.List;
@@ -18,8 +19,8 @@ public class LabelRepositoryTest {
     private LabelRepository repository;
 
     @Autowired
-    public LabelRepositoryTest(DataSource dataSource) {
-        this.repository = new LabelRepository(dataSource);
+    public LabelRepositoryTest(NamedParameterJdbcTemplate template) {
+        this.repository = new LabelRepository(template);
     }
 
     @DisplayName("이슈 아이디로 해당 이슈의 모든 label 정보를 불러온다.")

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepositoryTest.java
@@ -8,13 +8,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
-import javax.sql.DataSource;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @RepositoryTest
-public class LabelRepositoryTest {
+class LabelRepositoryTest {
 
     private LabelRepository repository;
 
@@ -25,25 +24,31 @@ public class LabelRepositoryTest {
 
     @DisplayName("이슈 아이디로 해당 이슈의 모든 label 정보를 불러온다.")
     @Test
-    void findAllByIssueIdTest() {
+    void findAllByIssueId() {
+        //when
         List<LabelVO> actual = repository.findAllByIssueId(3L);
 
-        assertThat(actual.size()).isEqualTo(2);
-        assertThat(actual.get(0).getName()).isEqualTo("라벨 1");
-        assertThat(actual.get(0).getBackgroundColor()).isEqualTo("#F08080");
-        assertThat(actual.get(1).getTextColor()).isEqualTo("#000000");
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual).hasSize(2);
+            assertions.assertThat(actual.get(0).getName()).isEqualTo("라벨 1");
+            assertions.assertThat(actual.get(0).getBackgroundColor()).isEqualTo("#F08080");
+            assertions.assertThat(actual.get(1).getTextColor()).isEqualTo("#000000");
+        });
     }
 
     @DisplayName("모든 라벨을 찾아 이름 순으로 반환한다.")
     @Test
-    void testFindAll() {
-
+    void findAll() {
+        //when
         List<LabelDetailsVO> actual = repository.findAll();
-        assertThat(actual.size()).isEqualTo(4);
-        assertThat(actual.get(0).getName()).isEqualTo("라벨 0");
-        assertThat(actual.get(1).getName()).isEqualTo("라벨 1");
-        assertThat(actual.get(2).getName()).isEqualTo("라벨 2");
-        assertThat(actual.get(3).getName()).isEqualTo("라벨 3");
 
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual).hasSize(4);
+            assertions.assertThat(actual.get(0).getName()).isEqualTo("라벨 0");
+            assertions.assertThat(actual.get(1).getName()).isEqualTo("라벨 1");
+            assertions.assertThat(actual.get(3).getName()).isEqualTo("라벨 3");
+        });
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/service/LabelServiceTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/service/LabelServiceTest.java
@@ -1,26 +1,27 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
-
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.ServiceTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.LabelRepository;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelDetailsVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.information.LabelPageInformation;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.StatRepository;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.StatVO;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
+import java.util.List;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
 
 @ServiceTest
 class LabelServiceTest {
 
     @InjectMocks
     LabelService labelService;
+
     @Mock
     StatRepository statRepository;
     @Mock
@@ -28,16 +29,21 @@ class LabelServiceTest {
 
     @DisplayName("레포지토리에서 라벨 관련 정보들을 받고 LabelPageInformation으로 변환할 수 있다.")
     @Test
-    void testReadLabelPage() {
+    void transformToLabelPageInformation() {
+        //given
         given(statRepository.countLabelStats()).willReturn(createDummyStatVO());
         given(labelRepository.findAll()).willReturn(createDummyLabelDetailsVOs());
 
+        //when
         LabelPageInformation actual = labelService.readLabelPage();
 
-        assertThat(actual.getLabelCount()).isEqualTo(3);
-        assertThat(actual.getMilestoneCount()).isEqualTo(4);
-        assertThat(actual.getLabelDetailsInformations().size()).isEqualTo(3);
-        assertThat(actual.getLabelDetailsInformations().get(0).getName()).isEqualTo("tmp1");
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual.getLabelCount()).isEqualTo(3);
+            assertions.assertThat(actual.getMilestoneCount()).isEqualTo(4);
+            assertions.assertThat(actual.getLabelDetailsInformations()).hasSize(3);
+            assertions.assertThat(actual.getLabelDetailsInformations().get(0).getName()).isEqualTo("tmp1");
+        });
     }
 
     private StatVO createDummyStatVO() {

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/MilestoneControllerTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/MilestoneControllerTest.java
@@ -1,17 +1,9 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.ControllerTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.MilestoneService;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.information.MilestoneDetailsInformation;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.information.MilestonePageInformation;
-
-import java.time.LocalDate;
-import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,12 +11,16 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
 @ControllerTest(MilestoneController.class)
-public class MilestoneControllerTest {
+class MilestoneControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -34,11 +30,14 @@ public class MilestoneControllerTest {
 
     @DisplayName("열린 마일스톤에 관한 MilestonePageInformation을 MilestonePageResponse로 변환한다.")
     @Test
-    void testReadOpenMilestones() throws Exception {
+    void transformToMileStonePageResponse() throws Exception {
+        //given
         given(milestoneService.readOpenMilestonePage()).willReturn(createDummyMilestonePageInformation());
 
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/milestones/open"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
                 .andExpectAll(

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/MilestoneControllerTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/MilestoneControllerTest.java
@@ -8,8 +8,10 @@ import codesquad.kr.gyeonggidoidle.issuetracker.annotation.ControllerTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.MilestoneService;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.information.MilestoneDetailsInformation;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.information.MilestonePageInformation;
+
 import java.time.LocalDate;
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,11 +41,13 @@ public class MilestoneControllerTest {
 
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.closeMilestoneCount").value(0))
-                .andExpect(jsonPath("$.labelCount").value(6))
-                .andExpect(jsonPath("$.milestones.length()").value(2))
-                .andExpect(jsonPath("$.milestones.[0].dueDate").value("2024-12-25"))
-                .andExpect(jsonPath("$.milestones.[1].name").value("tmp2"));
+                .andExpectAll(
+                        jsonPath("$.closeMilestoneCount").value(0),
+                        jsonPath("$.labelCount").value(6),
+                        jsonPath("$.milestones.length()").value(2),
+                        jsonPath("$.milestones.[0].dueDate").value("2024-12-25"),
+                        jsonPath("$.milestones.[1].name").value("tmp2")
+                );
     }
 
     private MilestonePageInformation createDummyMilestonePageInformation() {
@@ -60,7 +64,7 @@ public class MilestoneControllerTest {
                 .id(1L)
                 .name("tmp1")
                 .description("test")
-                .dueDate(LocalDate.of(2024,12,25))
+                .dueDate(LocalDate.of(2024, 12, 25))
                 .openIssueCount(1)
                 .closedIssuesCount(2)
                 .build();
@@ -74,5 +78,4 @@ public class MilestoneControllerTest {
                 .build();
         return List.of(tmp1, tmp2);
     }
-
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/integration/MilestoneIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/integration/MilestoneIntegrationTest.java
@@ -13,7 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @IntegrationTest
-public class MilestoneIntegrationTest {
+class MilestoneIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -25,12 +25,13 @@ public class MilestoneIntegrationTest {
 
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.openMilestoneCount").value(3))
-                .andExpect(jsonPath("$.closeMilestoneCount").value(1))
-                .andExpect(jsonPath("$.labelCount").value(4))
-                .andExpect(jsonPath("$.milestones.length()").value(3))
-                .andExpect(jsonPath("$.milestones.[0].name").value("마일스톤 0"))
-                .andDo(print());
+                .andExpectAll(
+                        jsonPath("$.openMilestoneCount").value(3),
+                        jsonPath("$.closeMilestoneCount").value(1),
+                        jsonPath("$.labelCount").value(4),
+                        jsonPath("$.milestones.length()").value(3),
+                        jsonPath("$.milestones.[0].name").value("마일스톤 0")
+                );
     }
 
     @DisplayName("닫힌 마일스톤의 모드 정보를 가지고 온다.")
@@ -40,11 +41,12 @@ public class MilestoneIntegrationTest {
 
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.openMilestoneCount").value(3))
-                .andExpect(jsonPath("$.closeMilestoneCount").value(1))
-                .andExpect(jsonPath("$.labelCount").value(4))
-                .andExpect(jsonPath("$.milestones.length()").value(1))
-                .andExpect(jsonPath("$.milestones.[0].name").value("마일스톤 2"))
-                .andDo(print());
+                .andExpectAll(
+                        jsonPath("$.openMilestoneCount").value(3),
+                        jsonPath("$.closeMilestoneCount").value(1),
+                        jsonPath("$.labelCount").value(4),
+                        jsonPath("$.milestones.length()").value(1),
+                        jsonPath("$.milestones.[0].name").value("마일스톤 2")
+                );
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/integration/MilestoneIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/integration/MilestoneIntegrationTest.java
@@ -1,16 +1,15 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.integration;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @IntegrationTest
 class MilestoneIntegrationTest {
@@ -20,9 +19,11 @@ class MilestoneIntegrationTest {
 
     @DisplayName("열린 마일스톤의 모드 정보를 가지고 온다.")
     @Test
-    void testReadOpenMilestones() throws Exception {
+    void getOpenMilestones() throws Exception {
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/milestones/open"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
                 .andExpectAll(
@@ -36,9 +37,11 @@ class MilestoneIntegrationTest {
 
     @DisplayName("닫힌 마일스톤의 모드 정보를 가지고 온다.")
     @Test
-    void testReadClosedMilestones() throws Exception {
+    void readClosedMilestones() throws Exception {
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/milestones/closed"));
 
+        //then
         resultActions
                 .andExpect(status().isOk())
                 .andExpectAll(

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/MilestoneRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/MilestoneRepositoryTest.java
@@ -10,6 +10,7 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 @RepositoryTest
 class MilestoneRepositoryTest {
@@ -17,8 +18,8 @@ class MilestoneRepositoryTest {
     private MilestoneRepository repository;
 
     @Autowired
-    public MilestoneRepositoryTest(DataSource dataSource) {
-        this.repository = new MilestoneRepository(dataSource);
+    public MilestoneRepositoryTest(NamedParameterJdbcTemplate template) {
+        this.repository = new MilestoneRepository(template);
     }
 
     @DisplayName("열린 마일스톤을 이름 순으로 가져온다.")

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/MilestoneRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/MilestoneRepositoryTest.java
@@ -1,16 +1,16 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.RepositoryTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.vo.MilestoneDetailsVO;
-import java.util.List;
-import javax.sql.DataSource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @RepositoryTest
 class MilestoneRepositoryTest {
@@ -24,24 +24,32 @@ class MilestoneRepositoryTest {
 
     @DisplayName("열린 마일스톤을 이름 순으로 가져온다.")
     @Test
-    void testFindOpenMilestones() {
+    void findOpenMilestones() {
+        //when
         List<MilestoneDetailsVO> actual = repository.findOpenMilestones();
 
-        assertThat(actual.size()).isEqualTo(3);
-        assertThat(actual.get(0).getName()).isEqualTo("마일스톤 0");
-        assertThat(actual.get(1).getName()).isEqualTo("마일스톤 1");
-        assertThat(actual.get(2).getName()).isEqualTo("마일스톤 3");
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual).hasSize(3);
+            assertions.assertThat(actual.get(0).getName()).isEqualTo("마일스톤 0");
+            assertions.assertThat(actual.get(1).getName()).isEqualTo("마일스톤 1");
+            assertions.assertThat(actual.get(2).getName()).isEqualTo("마일스톤 3");
+        });
     }
 
     @DisplayName("모든 마일스톤 정보를 이름 순으로 가지고 온다.")
     @Test
-    void testFindAllFilters() {
+    void findAll() {
+        //when
         List<MilestoneDetailsVO> actual = repository.findAllFilters();
 
-        assertThat(actual.size()).isEqualTo(4);
-        assertThat(actual.get(0).getName()).isEqualTo("마일스톤 0");
-        assertThat(actual.get(1).getName()).isEqualTo("마일스톤 1");
-        assertThat(actual.get(2).getName()).isEqualTo("마일스톤 2");
-        assertThat(actual.get(3).getName()).isEqualTo("마일스톤 3");
+        //then
+        assertSoftly(assertions -> {
+            assertThat(actual).hasSize(4);
+            assertThat(actual.get(0).getName()).isEqualTo("마일스톤 0");
+            assertThat(actual.get(1).getName()).isEqualTo("마일스톤 1");
+            assertThat(actual.get(2).getName()).isEqualTo("마일스톤 2");
+            assertThat(actual.get(3).getName()).isEqualTo("마일스톤 3");
+        });
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/service/MilestoneServiceTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/service/MilestoneServiceTest.java
@@ -1,50 +1,56 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.ServiceTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.MilestoneRepository;
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.vo.MilestoneDetailsVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.information.MilestonePageInformation;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.StatRepository;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.MilestoneStatVO;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.ArgumentMatchers.any;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @ServiceTest
 class MilestoneServiceTest {
 
     @InjectMocks
     MilestoneService milestoneService;
+
     @Mock
     StatRepository statRepository;
-
     @Mock
     MilestoneRepository milestoneRepository;
 
     @DisplayName("레포지토리에서 열린 마일스톤 정보들을 받고 MilestonePageInformation으로 변환할 수 있다.")
     @Test
-    void testReadOpenMilestonePage() {
+    void transformToMilestonePageInformation() {
+        //given
         given(statRepository.countMilestoneStats()).willReturn(createDummyMilestoneStatVO());
         given(milestoneRepository.findOpenMilestones()).willReturn(createDummyMilestoneDetailsVOs());
         given(statRepository.findIssuesCountByMilestoneIds(any())).willReturn(createDummyIssueByMilestoneVOs());
 
+        //when
         MilestonePageInformation actual = milestoneService.readOpenMilestonePage();
 
-        assertThat(actual.getOpenMilestoneCount()).isEqualTo(1);
-        assertThat(actual.getMilestoneDetailsInformations().get(0).getDueDate()).isEqualTo(LocalDate.now());
-        assertThat(actual.getMilestoneDetailsInformations().get(1).getDueDate()).isEqualTo("1998-10-27");
-        assertThat(actual.getMilestoneDetailsInformations().size()).isEqualTo(3);
-
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual.getOpenMilestoneCount()).isEqualTo(1);
+            assertions.assertThat(actual.getMilestoneDetailsInformations().get(0).getDueDate())
+                    .isEqualTo(LocalDate.now());
+            assertions.assertThat(actual.getMilestoneDetailsInformations().get(1).getDueDate())
+                    .isEqualTo("1998-10-27");
+            assertions.assertThat(actual.getMilestoneDetailsInformations().size()).isEqualTo(3);
+        });
     }
 
     private MilestoneStatVO createDummyMilestoneStatVO() {
@@ -68,7 +74,7 @@ class MilestoneServiceTest {
                 .id(2L)
                 .name("tmp2")
                 .description("test")
-                .dueDate(LocalDate.of(1998,10,27))
+                .dueDate(LocalDate.of(1998, 10, 27))
                 .openIssueCount(3)
                 .closedIssuesCount(4)
                 .build();
@@ -80,7 +86,7 @@ class MilestoneServiceTest {
                 .openIssueCount(5)
                 .closedIssuesCount(6)
                 .build();
-        return List.of(tmp1,tmp2,tmp3);
+        return List.of(tmp1, tmp2, tmp3);
     }
 
     private Map<Long, IssueByMilestoneVO> createDummyIssueByMilestoneVOs() {

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/stat/repository/StatRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/stat/repository/StatRepositoryTest.java
@@ -10,9 +10,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-
-import javax.sql.DataSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -23,8 +21,8 @@ public class StatRepositoryTest {
     private StatRepository repository;
 
     @Autowired
-    public StatRepositoryTest(DataSource dataSource) {
-        this.repository = new StatRepository(dataSource);
+    public StatRepositoryTest(NamedParameterJdbcTemplate template) {
+        this.repository = new StatRepository(template);
     }
 
     @DisplayName("전체적인 통계 정보를 가져온다.")

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/stat/repository/StatRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/stat/repository/StatRepositoryTest.java
@@ -4,19 +4,18 @@ import codesquad.kr.gyeonggidoidle.issuetracker.annotation.RepositoryTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.MilestoneStatVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.StatVO;
-import java.util.List;
-import java.util.Map;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @RepositoryTest
-public class StatRepositoryTest {
+class StatRepositoryTest {
 
     private StatRepository repository;
 
@@ -27,55 +26,61 @@ public class StatRepositoryTest {
 
     @DisplayName("전체적인 통계 정보를 가져온다.")
     @Test
-    void getOverallStatsTest() {
+    void getOverallStats() {
+        //when
         StatVO actual = repository.countOverallStats();
 
-        assertThat(actual.getLabelCount()).isEqualTo(4);
-        assertThat(actual.getMilestoneCount()).isEqualTo(4);
-        assertThat(actual.getClosedIssueCount()).isEqualTo(3);
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual.getLabelCount()).isEqualTo(4);
+            assertions.assertThat(actual.getMilestoneCount()).isEqualTo(4);
+            assertions.assertThat(actual.getClosedIssueCount()).isEqualTo(3);
+        });
     }
 
     @DisplayName("열린 마일스톤 개수와 닫힌 마일스톤 개수를 반환한다.")
     @Test
-    void testCountMilestoneStats() {
+    void countMilestoneStats() {
+        //when
         MilestoneStatVO actual = repository.countMilestoneStats();
 
-        assertThat(actual.getOpenMilestoneCount()).isEqualTo(3);
-        assertThat(actual.getCloseMilestoneCount()).isEqualTo(1);
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual.getOpenMilestoneCount()).isEqualTo(3);
+            assertions.assertThat(actual.getCloseMilestoneCount()).isEqualTo(1);
+        });
     }
 
     @DisplayName("총 마일스톤 개수와 라벨 개수를 반환한다.")
     @Test
-    void testCountLabelStats() {
+    void countLabelStats() {
+        //when
         StatVO actual = repository.countLabelStats();
 
-        assertThat(actual.getOpenIssueCount()).isNull();
-        assertThat(actual.getClosedIssueCount()).isNull();
-        assertThat(actual.getMilestoneCount()).isEqualTo(4);
-        assertThat(actual.getLabelCount()).isEqualTo(4);
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual.getOpenIssueCount()).isNull();
+            assertions.assertThat(actual.getClosedIssueCount()).isNull();
+            assertions.assertThat(actual.getMilestoneCount()).isEqualTo(4);
+            assertions.assertThat(actual.getLabelCount()).isEqualTo(4);
+        });
     }
 
     @DisplayName("마일스톤 당 열린 이슈와 닫힌 이슈 개수를 반환한다.")
     @Test
-    void testFindIssuesCountByMilestoneIds() {
-        Map<Long, IssueByMilestoneVO> actual = repository.findIssuesCountByMilestoneIds(List.of(1L,2L,3L));
+    void countIssuesCountByMilestoneIds() {
+        //when
+        Map<Long, IssueByMilestoneVO> actual = repository.findIssuesCountByMilestoneIds(List.of(1L, 2L, 3L));
 
-        assertThat(actual.size()).isEqualTo(3);
-
-        assertThrows(NullPointerException.class, ()->{
-            actual.get(0L).getOpenIssueCount();
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual).hasSize(3);
+            assertions.assertThat(actual.get(1L).getOpenIssueCount()).isEqualTo(1);
+            assertions.assertThat(actual.get(1L).getClosedIssueCount()).isEqualTo(2);
+            assertions.assertThat(actual.get(2L).getOpenIssueCount()).isEqualTo(0);
+            assertions.assertThat(actual.get(2L).getClosedIssueCount()).isEqualTo(1);
+            assertions.assertThat(actual.get(3L).getOpenIssueCount()).isEqualTo(1);
+            assertions.assertThat(actual.get(3L).getClosedIssueCount()).isEqualTo(0);
         });
-        assertThrows(NullPointerException.class, ()->{
-            actual.get(0L).getClosedIssueCount();
-        });
-
-        assertThat(actual.get(1L).getOpenIssueCount()).isEqualTo(1);
-        assertThat(actual.get(1L).getClosedIssueCount()).isEqualTo(2);
-
-        assertThat(actual.get(2L).getOpenIssueCount()).isEqualTo(0);
-        assertThat(actual.get(2L).getClosedIssueCount()).isEqualTo(1);
-
-        assertThat(actual.get(3L).getOpenIssueCount()).isEqualTo(1);
-        assertThat(actual.get(3L).getClosedIssueCount()).isEqualTo(0);
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/member/repository/MemberRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/member/repository/MemberRepositoryTest.java
@@ -8,13 +8,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
-import javax.sql.DataSource;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @RepositoryTest
-public class MemberRepositoryTest {
+class MemberRepositoryTest {
 
     private MemberRepository repository;
 
@@ -25,22 +24,30 @@ public class MemberRepositoryTest {
 
     @DisplayName("이슈아이디로 해당 이슈의 모든 할당자의 프로필을 가지고 온다.")
     @Test
-    void findAllProfilesByIssueIdTest() {
+    void findAllProfilesByIssueId() {
+        //when
         List<String> actual = repository.findAllProfilesByIssueId(1L);
 
-        assertThat(actual.size()).isEqualTo(2);
-        assertThat(actual.get(0)).isEqualTo("https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png");
-        assertThat(actual.get(1)).isEqualTo("https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png");
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual).hasSize(2);
+            assertions.assertThat(actual.get(0)).isEqualTo("https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png");
+            assertions.assertThat(actual.get(1)).isEqualTo("https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png");
+        });
     }
 
     @DisplayName("모든 가입자의 정보를 이름 순으로 가지고 온다.")
     @Test
-    void testFindAllFilters() {
+    void findAllFilters() {
+        //when
         List<MemberDetailsVO> actual = repository.findAllFilters();
 
-        assertThat(actual.size()).isEqualTo(3);
-        assertThat(actual.get(0).getName()).isEqualTo("ati");
-        assertThat(actual.get(1).getName()).isEqualTo("joy");
-        assertThat(actual.get(2).getName()).isEqualTo("nag");
+        //then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual).hasSize(3);
+            assertions.assertThat(actual.get(0).getName()).isEqualTo("ati");
+            assertions.assertThat(actual.get(1).getName()).isEqualTo("joy");
+            assertions.assertThat(actual.get(2).getName()).isEqualTo("nag");
+        });
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/member/repository/MemberRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/member/repository/MemberRepositoryTest.java
@@ -6,6 +6,7 @@ import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository.vo.Memb
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import javax.sql.DataSource;
 import java.util.List;
@@ -18,8 +19,8 @@ public class MemberRepositoryTest {
     private MemberRepository repository;
 
     @Autowired
-    public MemberRepositoryTest(DataSource dataSource) {
-        this.repository = new MemberRepository(dataSource);
+    public MemberRepositoryTest(NamedParameterJdbcTemplate template) {
+        this.repository = new MemberRepository(template);
     }
 
     @DisplayName("이슈아이디로 해당 이슈의 모든 할당자의 프로필을 가지고 온다.")

--- a/be/src/test/resources/schema/data.sql
+++ b/be/src/test/resources/schema/data.sql
@@ -1,7 +1,10 @@
 INSERT INTO member (email, name, password, profile)
-values ('nag@codesquad.kr', 'nag', '1q2w3e4r!', 'https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png'),
-       ('joy@codesquad.kr', 'joy', '1q2w3e4r!', 'https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png'),
-       ('ati@codesquad.kr', 'ati', '1q2w3e4r!', 'https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png');
+values ('nag@codesquad.kr', 'nag', '1q2w3e4r!',
+        'https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png'),
+       ('joy@codesquad.kr', 'joy', '1q2w3e4r!',
+        'https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png'),
+       ('ati@codesquad.kr', 'ati', '1q2w3e4r!',
+        'https://e7.pngegg.com/pngimages/981/645/png-clipart-default-profile-united-states-computer-icons-desktop-free-high-quality-person-icon-miscellaneous-silhouette.png');
 
 INSERT INTO milestone (name, due_date, is_open)
 values ('마일스톤 1', current_date, 1),
@@ -42,7 +45,7 @@ values (1, 1),
        (4, 2),
        (4, 3);
 
-INSERT INTO  comment (issue_id, author_id, contents)
+INSERT INTO comment (issue_id, author_id, contents)
 values (1, 1, '1번 댓글입니다.'),
        (1, 2, '2번 댓글입니다.'),
        (1, 2, '3번 댓글입니다.'),


### PR DESCRIPTION
### 구현 내용

테스트 코트의 수정, main 코드 정리

### 상세 내용

- Repository 생성시 Datasource 대신 JdbcTemplate을 주입, 롬북으로 생성자를 만들어 가독성 향상
- RepositoryTest에서 Datasource 대신 JdbcTemplate을 주입하도록 변경
- 테스트 코드의 네이밍에서 test를 제거하여 가독성 향상
- 테스트 코드에 given, when, then의 주석을 넣어 가독성 향상
- ControllerTest와 IntegrationTest에서 json 값을 검증할 때 .andExpect() 대신 .andExpectAll()을 적용, 하나로 묶어 가독성 향상
- 테스트 코드의 assertThat()를 assertSoftly()로 감싸, 하나의 assert문이 실패해도 다음 assert문이 실행되도록 수정
- main의 코드의 import문 정리
- application.yml에서 쓰지않는 hibernate 설정 제거
