### PR TITLE
[BE]: JWT 로그인, 로그아웃 기능 구현 (#57) (#62)

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -34,6 +34,11 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
+
 }
 
 tasks.named('test') {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/config/FilterConfig.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/config/FilterConfig.java
@@ -1,0 +1,21 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.config;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.JwtAuthorizationFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.servlet.Filter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<Filter> jwtAuthorizationFilter(ObjectMapper objectMapper) {
+
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new JwtAuthorizationFilter(objectMapper));
+        filterRegistrationBean.setOrder(1);
+        return filterRegistrationBean;
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/ApiResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/contoller/response/ApiResponse.java
@@ -4,15 +4,22 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class ApiResponse {
+public class ApiResponse<T> {
 
     private final int statusCode;
+    private final T data;
 
-    public ApiResponse(int statusCode) {
+    private ApiResponse(int statusCode, T data) {
         this.statusCode = statusCode;
+        this.data = data;
     }
 
     public static ApiResponse success(HttpStatus status) {
-        return new ApiResponse(status.value());
+        return new ApiResponse(status.value(), null);
+    }
+
+    public static ApiResponse exception(HttpStatus status, String data) {
+        return new ApiResponse<>(status.value(), data);
+
     }
 }

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepository.java
@@ -4,6 +4,7 @@ import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.Issue;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.vo.IssueStatusVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.vo.IssueUpdateVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.vo.IssueVO;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -20,6 +21,7 @@ import java.util.Map;
 public class IssueRepository {
 
     private final NamedParameterJdbcTemplate template;
+
     private final RowMapper<IssueVO> issueVOMapper = (rs, rowNum) -> IssueVO.builder()
             .id(rs.getLong("id"))
             .author(rs.getString("author_name"))

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/JwtAuthorizationFilter.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/JwtAuthorizationFilter.java
@@ -1,0 +1,89 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.response.ApiResponse;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.JwtProvider;
+import codesquad.kr.gyeonggidoidle.issuetracker.exception.JwtExceptionType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.MalformedJwtException;
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.util.PatternMatchUtils;
+
+public class JwtAuthorizationFilter implements Filter {
+
+    private final String[] whiteListUris = new String[]{"/api/login", "/api/signup", "/api/auth/reissue"};
+    private final JwtProvider jwtProvider = new JwtProvider();
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthorizationFilter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+
+        if (httpServletRequest.getMethod().equals("OPTIONS")) {
+            return;
+        }
+        if (whiteListCheck(httpServletRequest.getRequestURI())) {
+            chain.doFilter(request, response);
+            return;
+        }
+        if (!isContainToken(httpServletRequest)) {
+            sendErrorApiResponse(response, new MalformedJwtException(""));
+            return;
+        }
+        try {
+            String token = getToken(httpServletRequest);
+            Claims claims = jwtProvider.getClaims(token);
+            request.setAttribute("memberId", claims.get("memberId")); // TODO: email으로 수정 고려
+            chain.doFilter(request, response);
+        } catch (RuntimeException e) {
+            sendErrorApiResponse(response, e);
+        }
+
+    }
+
+    private String getToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        return authorization.substring(7).replace("\"","");
+    }
+
+    private boolean whiteListCheck(String uri) {
+        return PatternMatchUtils.simpleMatch(whiteListUris, uri);
+    }
+
+    private boolean isContainToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        return authorization != null && authorization.startsWith("Bearer ");
+    }
+
+    private void sendErrorApiResponse(ServletResponse response, RuntimeException e) throws IOException {
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        ((HttpServletResponse) response).setStatus(HttpStatus.UNAUTHORIZED.value());
+
+        response.getWriter().write(
+                objectMapper.writeValueAsString(
+                    generateErrorApiResponse(e))
+        );
+    }
+
+    private ApiResponse generateErrorApiResponse(RuntimeException e) {
+        JwtExceptionType jwtExceptionType = JwtExceptionType.from(e);
+        return ApiResponse.exception(jwtExceptionType.getHttpstatus(), jwtExceptionType.getMessage());
+    }
+
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/JwtController.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/JwtController.java
@@ -1,0 +1,44 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.response.ApiResponse;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request.LoginRequest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request.RefreshTokenRequest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request.SignUpRequest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.response.JwtResponse;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.service.JwtService;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class JwtController {
+
+    private final JwtService jwtService;
+
+    @PostMapping("/api/login")
+    public JwtResponse login(@RequestBody @Valid LoginRequest request) {
+        return JwtResponse.from(jwtService.login(LoginRequest.to(request)));
+    }
+
+    @PostMapping("/api/signup")
+    public ApiResponse signUp(@RequestBody @Valid SignUpRequest request) {
+        jwtService.signUp(SignUpRequest.to(request));
+        return ApiResponse.success(HttpStatus.OK);
+    }
+
+    @PostMapping("/api/auth/reissue")
+    public JwtResponse reissueAccessToken(@RequestBody RefreshTokenRequest request) {
+        return JwtResponse.from(jwtService.reissueAccessToken(request.getRefreshToken()));
+    }
+
+    @PostMapping("/api/logout")
+    public ApiResponse logout(HttpServletRequest request) {
+        jwtService.logout(Long.parseLong(String.valueOf(request.getAttribute("memberId"))));
+        return ApiResponse.success(HttpStatus.OK);
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/request/LoginRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/request/LoginRequest.java
@@ -1,0 +1,29 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.service.condition.LoginCondition;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+
+    @Email
+    private final String email;
+    @NotBlank
+    private final String password;
+
+    @Builder
+    private LoginRequest(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    public static LoginCondition to(LoginRequest request) {
+        return LoginCondition.builder()
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .build();
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/request/RefreshTokenRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/request/RefreshTokenRequest.java
@@ -1,0 +1,17 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class RefreshTokenRequest {
+
+    private String refreshToken;
+
+    public RefreshTokenRequest(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public RefreshTokenRequest(){}
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/request/SignUpRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/request/SignUpRequest.java
@@ -1,0 +1,33 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.service.condition.SignUpCondition;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SignUpRequest {
+
+    @Email
+    private final String email;
+    @NotBlank
+    private final String password;
+    @NotBlank
+    private final String profile;
+
+    @Builder
+    private SignUpRequest(String email, String password, String profile) {
+        this.email = email;
+        this.password = password;
+        this.profile = profile;
+    }
+
+    public static SignUpCondition to(SignUpRequest request) {
+        return SignUpCondition.builder()
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .profile(request.getProfile())
+                .build();
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/response/JwtResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/response/JwtResponse.java
@@ -1,0 +1,25 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.response;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.Jwt;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class JwtResponse {
+
+    private final String accessToken;
+    private final String refreshToken;
+
+    @Builder
+    private JwtResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public static JwtResponse from(Jwt jwt) {
+        return JwtResponse.builder()
+                .accessToken(jwt.getAccessToken())
+                .refreshToken(jwt.getRefreshToken())
+                .build();
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/response/JwtTokenType.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/response/JwtTokenType.java
@@ -1,0 +1,6 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.response;
+
+public enum JwtTokenType {
+
+    ACCESS, REFRESH
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/entity/Jwt.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/entity/Jwt.java
@@ -1,0 +1,17 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Jwt {
+
+    private final String accessToken;
+    private final String refreshToken;
+
+    @Builder
+    private Jwt(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/entity/JwtProvider.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/entity/JwtProvider.java
@@ -1,0 +1,60 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtProvider {
+
+    private static final byte[] secret = "codesquad-issue-tracker-max-01-gyeonggidoidle".getBytes();
+    private final Key key = Keys.hmacShaKeyFor(secret);
+
+    public String createToken(Map<String, Object> claims, Date expireDate) {
+        return Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(expireDate)
+                .signWith(key)
+                .compact();
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public Jwt createJwt(Map<String, Object> claims) {
+        String accessToken = createToken(claims,getExpireDateAccessToken());
+        String refreshToken = createToken(new HashMap<>(), getExpireDateRefreshToken());
+        return Jwt.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public Jwt reissueAccessToken(Map<String, Object> claims, String refreshToken) {
+        String accessToken = createToken(claims, getExpireDateAccessToken());
+        return Jwt.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public Date getExpireDateAccessToken() {
+        long expireTimeMils = 1000L * 60 * 60; // 1시간
+        return new Date(System.currentTimeMillis() + expireTimeMils);
+    }
+
+    public Date getExpireDateRefreshToken() {
+        long expireTimeMils = 1000L * 60 * 60 * 24 * 60; // 60일
+        return new Date(System.currentTimeMillis() + expireTimeMils);
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/repository/JwtRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/repository/JwtRepository.java
@@ -1,0 +1,51 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.repository;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.Member;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class JwtRepository {
+
+    private final NamedParameterJdbcTemplate template;
+
+    public Member findByRefreshToken(String refreshToken) {
+        String sql = "SELECT member.id, member.email, member.name, member.password, member.profile "
+                + "FROM member "
+                + "JOIN refresh_token "
+                + "ON member.id = refresh_token.member_id "
+                + "WHERE refresh_token.refresh_token = :refreshToken";
+        try {
+            return template.queryForObject(sql, Map.of("refreshToken", refreshToken), memberRowMapper());
+        } catch (DataAccessException e) {
+            return null;
+        }
+    }
+
+    public void saveRefreshToken(String refreshToken, Long memberId) {
+        String sql = "INSERT INTO refresh_token(refresh_token, member_id) VALUES(:refreshToken, :memberId) "
+                + "ON DUPLICATE KEY UPDATE refresh_token = :refreshToken";
+        template.update(sql, Map.of("refreshToken", refreshToken, "memberId", memberId));
+    }
+
+    public boolean deleteRefreshToken(Long memberId) {
+        String sql = "DELETE FROM refresh_token WHERE member_id = :memberId";
+        int result = template.update(sql, Map.of("memberId", memberId));
+        return result > 0;
+    }
+
+    private final RowMapper<Member> memberRowMapper() {
+        return ((rs, rowNum) -> Member.builder()
+                .id(rs.getLong("id"))
+                .email(rs.getString("email"))
+                .name(rs.getString("name"))
+                .password(rs.getString("password"))
+                .profile(rs.getString("profile"))
+                .build());
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/service/JwtService.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/service/JwtService.java
@@ -1,0 +1,72 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.service;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.response.JwtTokenType;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.Jwt;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.JwtProvider;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.repository.JwtRepository;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.service.condition.LoginCondition;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.service.condition.SignUpCondition;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.Member;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository.MemberRepository;
+import codesquad.kr.gyeonggidoidle.issuetracker.exception.IllegalJwtTokenException;
+import codesquad.kr.gyeonggidoidle.issuetracker.exception.IllegalPasswordException;
+import codesquad.kr.gyeonggidoidle.issuetracker.exception.MemberDuplicationException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class JwtService {
+
+    private final JwtRepository jwtRepository;
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+
+    public Jwt login(LoginCondition condition) {
+        Member member = memberRepository.findByEmail(condition.getEmail());
+        if (!verifyPassword(member, condition.getPassword())) {
+            throw new IllegalPasswordException();
+        }
+        Jwt jwt = jwtProvider.createJwt(generateMemberClaims(member));
+        jwtRepository.saveRefreshToken(jwt.getRefreshToken(), member.getId());
+        return jwt;
+    }
+
+    @Transactional
+    public void signUp(SignUpCondition condition) {
+        String email = condition.getEmail();
+        if (existMember(memberRepository.findByEmail(email))) {
+            throw new MemberDuplicationException(email);
+        }
+        memberRepository.saveMember(SignUpCondition.to(condition));
+    }
+
+    @Transactional
+    public Jwt reissueAccessToken(String refreshToken) {
+        Member member = jwtRepository.findByRefreshToken(refreshToken);
+        if (member == null) {
+            throw new IllegalJwtTokenException(JwtTokenType.REFRESH);
+        }
+        return jwtProvider.reissueAccessToken(generateMemberClaims(member), refreshToken);
+    }
+
+    public void logout(Long memberId ) {
+        if (!jwtRepository.deleteRefreshToken(memberId)) {
+            throw new IllegalJwtTokenException(JwtTokenType.REFRESH);
+        }
+    }
+
+    private Map<String, Object> generateMemberClaims(Member member) {
+        return Map.of("memberId", member.getId());
+    }
+
+    private boolean existMember(Member member) {
+        return member != null;
+    }
+
+    private boolean verifyPassword(Member member, String password) {
+        return existMember(member) && member.getPassword().equals(password);
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/service/condition/LoginCondition.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/service/condition/LoginCondition.java
@@ -1,0 +1,17 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.service.condition;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LoginCondition {
+
+    private final String email;
+    private final String password;
+
+    @Builder
+    private LoginCondition(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/service/condition/SignUpCondition.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/service/condition/SignUpCondition.java
@@ -1,0 +1,29 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.service.condition;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SignUpCondition {
+
+    private final String email;
+    private final String password;
+    private final String profile;
+
+    @Builder
+    private SignUpCondition(String email, String password, String profile) {
+        this.email = email;
+        this.password = password;
+        this.profile = profile;
+    }
+
+    public static Member to(SignUpCondition condition) {
+        return Member.builder()
+                .email(condition.getEmail())
+                .password(condition.getPassword())
+                .name(Member.findUserName(condition.getEmail()))
+                .profile(condition.getProfile())
+                .build();
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepository.java
@@ -2,6 +2,7 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelDetailsVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelVO;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/Member.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/Member.java
@@ -1,5 +1,6 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.member;
 
+import codesquad.kr.gyeonggidoidle.issuetracker.exception.IllegalEmailException;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,5 +20,13 @@ public class Member {
         this.name = name;
         this.password = password;
         this.profile = profile;
+    }
+
+    public static String findUserName(String email) {
+        int idx = email.indexOf('@');
+        if (idx == -1) {
+            throw new IllegalEmailException();
+        }
+        return email.substring(0,idx);
     }
 }

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/repository/MemberRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/repository/MemberRepository.java
@@ -1,22 +1,29 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository;
 
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.Member;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository.vo.MemberDetailsVO;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Repository
 public class MemberRepository {
 
     private final NamedParameterJdbcTemplate template;
+
 
     public Map<Long, List<String>> findAllProfilesByIssueIds(List<Long> issueIds) {
         return issueIds.stream()
@@ -66,10 +73,39 @@ public class MemberRepository {
         return template.query(sql, new MapSqlParameterSource(), memberDetailsVORowMapper());
     }
 
+    public Member findByEmail(String email) {
+        String sql = "SELECT id, email, name, password, profile FROM member WHERE email = :email";
+        try {
+            return template.queryForObject(sql, Map.of("email", email), memberRowMapper());
+        } catch (DataAccessException e) {
+            return null;
+        }
+    }
+
+    public void saveMember(Member member) {
+        String sql = "INSERT INTO member(name, email, password, profile) VALUES(:name, :email, :password, :profile) ";
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("name", member.getName())
+                .addValue("email", member.getEmail())
+                .addValue("password", member.getPassword())
+                .addValue("profile", member.getProfile());
+        template.update(sql, params);
+    }
+
     private final RowMapper<MemberDetailsVO> memberDetailsVORowMapper() {
         return ((rs, rowNum) -> MemberDetailsVO.builder()
                 .id(rs.getLong("id"))
                 .name(rs.getString("name"))
+                .profile(rs.getString("profile"))
+                .build());
+    }
+
+    private final RowMapper<Member> memberRowMapper() {
+        return ((rs, rowNum) -> Member.builder()
+                .id(rs.getLong("id"))
+                .email(rs.getString("email"))
+                .name(rs.getString("name"))
+                .password(rs.getString("password"))
                 .profile(rs.getString("profile"))
                 .build());
     }

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/MilestoneRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/MilestoneRepository.java
@@ -1,13 +1,14 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.repository.vo.MilestoneDetailsVO;
+
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Repository

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/stat/repository/StatRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/stat/repository/StatRepository.java
@@ -3,6 +3,11 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.MilestoneStatVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.StatVO;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -10,15 +15,13 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Repository
 public class StatRepository {
 
     private final NamedParameterJdbcTemplate template;
+
     private final RowMapper<StatVO> statVORowMapper = (rs, rowNum) -> StatVO.builder()
             .openIssueCount(rs.getInt("open_issue_count"))
             .closedIssueCount(rs.getInt("closed_issue_count"))

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/CustomException.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/CustomException.java
@@ -1,0 +1,15 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+
+    public CustomException(HttpStatus httpStatus, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.exception;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.response.ApiResponse;
+import io.jsonwebtoken.JwtException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ApiResponse handleException(Exception e) {
+        return ApiResponse.exception(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
+    @ExceptionHandler(CustomException.class)
+    public ApiResponse handleException(CustomException e) {
+        return ApiResponse.exception(e.getHttpStatus(), e.getMessage());
+    }
+
+    @ExceptionHandler(JwtException.class)
+    public ApiResponse handleException(JwtException e) {
+        JwtExceptionType jwtExceptionType = JwtExceptionType.from(e);
+        return ApiResponse.exception(jwtExceptionType.getHttpstatus(), jwtExceptionType.getMessage());
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/IllegalEmailException.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/IllegalEmailException.java
@@ -1,0 +1,14 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class IllegalEmailException extends CustomException {
+
+    private static final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+
+    public IllegalEmailException() {
+        super(httpStatus, "형식에 맞지 않는 이메일입니다.");
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/IllegalJwtTokenException.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/IllegalJwtTokenException.java
@@ -1,0 +1,15 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.exception;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.response.JwtTokenType;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class IllegalJwtTokenException extends CustomException {
+
+    private static final HttpStatus httpStatus = HttpStatus.UNAUTHORIZED;
+
+    public IllegalJwtTokenException(JwtTokenType tokenType) {
+        super(httpStatus, "[Token 인증 오류]: 잘못된 " + tokenType.name() + " 토큰 입니다.");
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/IllegalPasswordException.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/IllegalPasswordException.java
@@ -1,0 +1,14 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class IllegalPasswordException extends CustomException {
+
+    private static final HttpStatus httpstatus = HttpStatus.UNAUTHORIZED;
+
+    public IllegalPasswordException() {
+        super(httpstatus, "비밀번호가 일치하지 않거나 존재하지 않는 회원입니다.");
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/JwtExceptionType.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/JwtExceptionType.java
@@ -1,0 +1,35 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.exception;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import java.security.SignatureException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+@Getter
+public enum JwtExceptionType {
+
+    EXPIRED_JWT_EXCEPTION(HttpStatus.UNAUTHORIZED, "기한이 만료되었습니다"),
+    MALFORMED_JWT_EXCEPTION(HttpStatus.UNAUTHORIZED, "잘못된 형식의 토큰입니다"),
+    SIGNATURE_EXCEPTION(HttpStatus.UNAUTHORIZED, "올바른 키가 아닙니다."),
+    ILLEGAL_ARGUMENT_EXCEPTION(HttpStatus.UNAUTHORIZED, "잘못된 값이 들어왔습니다.");
+
+    private final HttpStatus httpstatus;
+    private final String message;
+
+    JwtExceptionType(HttpStatus httpstatus, String message) {
+        this.httpstatus = httpstatus;
+        this.message = message;
+    }
+
+    public static JwtExceptionType from(RuntimeException e) {
+
+        if (e.getClass().equals(ExpiredJwtException.class)) {
+            return JwtExceptionType.EXPIRED_JWT_EXCEPTION;
+        } else if (e.getClass().equals(MalformedJwtException.class)) {
+            return JwtExceptionType.MALFORMED_JWT_EXCEPTION;
+        } else if (e.getClass().equals(SignatureException.class)) {
+            return JwtExceptionType.SIGNATURE_EXCEPTION;
+        }
+        return JwtExceptionType.ILLEGAL_ARGUMENT_EXCEPTION;
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/MemberDuplicationException.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/MemberDuplicationException.java
@@ -1,0 +1,14 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class MemberDuplicationException extends CustomException {
+
+    private static final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+
+    public MemberDuplicationException(String email) {
+        super(httpStatus, "해당 이메일은 이미 가입된 이메일 입니다. : " + email);
+    }
+}

--- a/be/src/main/resources/schema.sql
+++ b/be/src/main/resources/schema.sql
@@ -4,6 +4,7 @@ DROP Table if exists issue_label;
 DROP Table if exists issue;
 DROP Table if exists label;
 DROP Table if exists milestone;
+DROP Table if exists refresh_token;
 DROP Table if exists member;
 DROP Table if exists file;
 
@@ -86,6 +87,14 @@ CREATE TABLE comment
     PRIMARY KEY (id)
 );
 
+CREATE TABLE refresh_token
+(
+    id               bigint AUTO_INCREMENT,
+    refresh_token    varchar(2000),
+    member_id        bigint,
+    PRIMARY KEY (id)
+);
+
 ALTER TABLE issue
     ADD CONSTRAINT fk_issue_author_id FOREIGN KEY (author_id) REFERENCES member (id);
 
@@ -112,3 +121,6 @@ ALTER TABLE issue_assignee
 
 ALTER TABLE issue_assignee
     ADD CONSTRAINT fk_issue_assignee_assignee_id FOREIGN KEY (assignee_id) REFERENCES member (id);
+
+ALTER TABLE refresh_token
+    ADD CONSTRAINT fk_refresh_token_member_id FOREIGN KEY (member_id) REFERENCES member (id);

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/integration/IssueIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/integration/IssueIntegrationTest.java
@@ -1,6 +1,11 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.integration;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.IntegrationTest;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.Jwt;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.JwtProvider;
+import java.util.Map;
+
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.request.IssueCreateRequest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.request.IssueStatusRequest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.contoller.request.IssueUpdateRequest;
@@ -8,6 +13,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,13 +37,15 @@ class IssueIntegrationTest {
     private MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
+    private JwtProvider jwtProvider;
 
     @DisplayName("열린 이슈의 모든 정보를 다 가지고 온다.")
     @Test
     void getOpenIssues() throws Exception {
         //when
-        ResultActions resultActions = mockMvc.perform(get("/api/issues/open"));
+        Jwt jwt = makeToken();
+        ResultActions resultActions = mockMvc.perform(get("/api/issues/open")
+                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
         //then
         resultActions
@@ -56,7 +64,9 @@ class IssueIntegrationTest {
     @Test
     void getClosedIssues() throws Exception {
         //when
-        ResultActions resultActions = mockMvc.perform(get("/api/issues/closed"));
+        Jwt jwt = makeToken();
+        ResultActions resultActions = mockMvc.perform(get("/api/issues/closed")
+                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
         //then
         resultActions
@@ -75,7 +85,9 @@ class IssueIntegrationTest {
     @Test
     void getFilters() throws Exception {
         //when
-        ResultActions resultActions = mockMvc.perform(get("/api/filters"));
+        Jwt jwt = makeToken();
+        ResultActions resultActions = mockMvc.perform(get("/api/filters")
+                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
         //then
         resultActions
@@ -93,7 +105,9 @@ class IssueIntegrationTest {
     @Test
     void getFiltersByIssue() throws Exception {
         //when
-        ResultActions resultActions = mockMvc.perform(get("/api/issues"));
+        Jwt jwt = makeToken(); 
+        ResultActions resultActions = mockMvc.perform(get("/api/issues")
+                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
         //then
         resultActions
@@ -118,8 +132,10 @@ class IssueIntegrationTest {
                 .open(false)
                 .issues(List.of(4L,5L))
                 .build();
-
+      
+        Jwt jwt = makeToken(); 
         ResultActions resultActions = mockMvc.perform(patch("/api/issues")
+                .header("Authorization", "Bearer " + jwt.getAccessToken())                                      
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(request)));
 
@@ -130,7 +146,9 @@ class IssueIntegrationTest {
     @DisplayName("선택한 이슈를 삭제한다.")
     @Test
     void testDeleteIssue() throws Exception {
-        ResultActions resultActions = mockMvc.perform(delete("/api/issues/1"));
+        Jwt jwt = makeToken(); 
+        ResultActions resultActions = mockMvc.perform(delete("/api/issues/1")
+                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
         resultActions.andExpect(status().isOk())
                 .andDo(print());
@@ -143,7 +161,9 @@ class IssueIntegrationTest {
                 .open(false)
                 .build();
 
+        Jwt jwt = makeToken(); 
         ResultActions resultActions = mockMvc.perform(patch("/api/issues/2")
+                .header("Authorization", "Bearer " + jwt.getAccessToken())                                      
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(request)));
 
@@ -161,8 +181,10 @@ class IssueIntegrationTest {
                 .labels(List.of(2L))
                 .milestone(1L)
                 .build();
-
+        
+        Jwt jwt = makeToken(); 
         ResultActions resultActions = mockMvc.perform(post("/api/issues")
+                .header("Authorization", "Bearer " + jwt.getAccessToken())                                      
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(request)));
 
@@ -190,5 +212,10 @@ class IssueIntegrationTest {
 
     private <T> String toJson(T data) throws JsonProcessingException {
         return objectMapper.writeValueAsString(data);
+    }
+  
+    
+    private Jwt makeToken() {
+        return jwtProvider.createJwt(Map.of("memberId",1L));
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/repository/IssueRepositoryTest.java
@@ -1,7 +1,10 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.RepositoryTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.repository.vo.IssueVO;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/integration/JwtIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/integration/JwtIntegrationTest.java
@@ -1,0 +1,111 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.integration;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.annotation.IntegrationTest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request.LoginRequest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request.SignUpRequest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.Jwt;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.JwtProvider;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+
+@IntegrationTest
+public class JwtIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private JwtProvider jwtProvider;
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @DisplayName("이메일과 비밀번호를 받아 JwtResponse를 반환한다.")
+    @Test
+    @Order(1)
+    void login() throws Exception {
+        LoginRequest request = LoginRequest.builder()
+                .email("joy@codesquad.kr")
+                .password("1q2w3e4r!")
+                .build();
+
+        ResultActions resultActions = mockMvc.perform(post("/api/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)));
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpectAll(
+                        jsonPath("$.length()").value(2),
+                        jsonPath("$.accessToken").isNotEmpty(),
+                        jsonPath("$.refreshToken").isNotEmpty()
+                );
+    }
+
+    @DisplayName("이메일, 비밀번호, 프로필사진을 받아 회원가입을 한다.")
+    @Test
+    @Order(2)
+    void signUp() throws Exception {
+        SignUpRequest request = SignUpRequest.builder()
+                .email("test@test.com")
+                .password("!test1234")
+                .profile("profile1234")
+                .build();
+
+        ResultActions resultActions = mockMvc.perform(post("/api/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)));
+
+        resultActions
+                .andExpect(status().isOk());
+    }
+
+//    @DisplayName("refreshToken을 받아서 새로운 accessToken이 담긴 JwtResponse를 반환한다.")
+//    @Test
+//    @Order(3)
+//    void reissueAccessToken() throws Exception {
+//        Jwt jwt = makeToken();
+//        RefreshTokenRequest request = new RefreshTokenRequest(jwt.getRefreshToken());
+//        ResultActions resultActions = mockMvc.perform(post("/api/auth/reissue")
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .content(toJson(request)));
+//
+//        resultActions
+//                .andExpect(status().isOk())
+//                .andExpectAll(
+//                        jsonPath("$.length()").value(2),
+//                        jsonPath("$.accessToken").isNotEmpty(),
+//                        jsonPath("$.refreshToken").isNotEmpty()
+//                );
+//    }
+
+    @DisplayName("HttpServletRequest에 담긴 claim의 memberId를 가지고 refreshToken을 삭제한다.")
+    @Test
+    @Order(4)
+    void logout() throws Exception {
+        Jwt jwt = makeToken();
+        ResultActions resultActions = mockMvc.perform(post("/api/logout")
+                .header("Authorization", "Bearer " + jwt.getAccessToken()));
+
+        resultActions.andExpect(status().isOk());
+    }
+
+    private <T> String toJson(T data) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(data);
+    }
+
+    private Jwt makeToken() {
+        return jwtProvider.createJwt(Map.of("memberId",2L));
+    }
+}

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/integration/LabelIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/integration/LabelIntegrationTest.java
@@ -1,6 +1,9 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.label.integration;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.IntegrationTest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.Jwt;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.JwtProvider;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,11 +20,16 @@ class LabelIntegrationTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private JwtProvider jwtProvider;
+
     @DisplayName("라벨의 모드 정보를 가지고 온다.")
     @Test
     void getLabels() throws Exception {
         //when
-        ResultActions resultActions = mockMvc.perform(get("/api/labels"));
+        Jwt jwt = makeToken();
+        ResultActions resultActions = mockMvc.perform(get("/api/labels")
+                .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
         //then
         resultActions
@@ -32,5 +40,9 @@ class LabelIntegrationTest {
                         jsonPath("$.labels.length()").value(4),
                         jsonPath("$.labels.[0].name").value("라벨 0")
                 );
+    }
+
+    private Jwt makeToken() {
+        return jwtProvider.createJwt(Map.of("memberId",1L));
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepositoryTest.java
@@ -1,14 +1,15 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.RepositoryTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelDetailsVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.repository.VO.LabelVO;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-
-import java.util.List;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/integration/MilestoneIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/integration/MilestoneIntegrationTest.java
@@ -1,6 +1,9 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.integration;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.IntegrationTest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.Jwt;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.JwtProvider;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,11 +20,16 @@ class MilestoneIntegrationTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private JwtProvider jwtProvider;
+
     @DisplayName("열린 마일스톤의 모드 정보를 가지고 온다.")
     @Test
     void getOpenMilestones() throws Exception {
         //when
-        ResultActions resultActions = mockMvc.perform(get("/api/milestones/open"));
+        Jwt jwt = makeToken();
+        ResultActions resultActions = mockMvc.perform(get("/api/milestones/open")
+                .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
         //then
         resultActions
@@ -39,7 +47,9 @@ class MilestoneIntegrationTest {
     @Test
     void readClosedMilestones() throws Exception {
         //when
-        ResultActions resultActions = mockMvc.perform(get("/api/milestones/closed"));
+        Jwt jwt = makeToken();
+        ResultActions resultActions = mockMvc.perform(get("/api/milestones/closed")
+                .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
         //then
         resultActions
@@ -51,5 +61,9 @@ class MilestoneIntegrationTest {
                         jsonPath("$.milestones.length()").value(1),
                         jsonPath("$.milestones.[0].name").value("마일스톤 2")
                 );
+    }
+
+    private Jwt makeToken() {
+        return jwtProvider.createJwt(Map.of("memberId",1L));
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/stat/repository/StatRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/stat/repository/StatRepositoryTest.java
@@ -1,9 +1,13 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.RepositoryTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.IssueByMilestoneVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.MilestoneStatVO;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.stat.repository.vo.StatVO;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/member/repository/MemberRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/member/repository/MemberRepositoryTest.java
@@ -1,14 +1,17 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.member.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.RepositoryTest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.Member;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository.MemberRepository;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository.vo.MemberDetailsVO;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-
-import java.util.List;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -48,6 +51,20 @@ class MemberRepositoryTest {
             assertions.assertThat(actual.get(0).getName()).isEqualTo("ati");
             assertions.assertThat(actual.get(1).getName()).isEqualTo("joy");
             assertions.assertThat(actual.get(2).getName()).isEqualTo("nag");
+        });
+    }
+
+    @DisplayName("이메일로 해당 멤버를 찾는다.")
+    @Test
+    void findByEmail() {
+        // when
+        Member actual = repository.findByEmail("joy@codesquad.kr");
+
+        // then
+        assertSoftly(assertions -> {
+            assertions.assertThat(actual.getId()).isEqualTo(2);
+            assertions.assertThat(actual.getName()).isEqualTo("joy");
+            assertions.assertThat(actual.getPassword()).isEqualTo("1q2w3e4r!");
         });
     }
 }

--- a/be/src/test/resources/schema/schema.sql
+++ b/be/src/test/resources/schema/schema.sql
@@ -4,6 +4,7 @@ DROP Table if exists issue_label;
 DROP Table if exists issue;
 DROP Table if exists label;
 DROP Table if exists milestone;
+DROP Table if exists refresh_token;
 DROP Table if exists member;
 DROP Table if exists file;
 
@@ -86,6 +87,14 @@ CREATE TABLE comment
     PRIMARY KEY (id)
 );
 
+CREATE TABLE refresh_token
+(
+    id               bigint AUTO_INCREMENT,
+    refresh_token    varchar(2000),
+    member_id        bigint,
+    PRIMARY KEY (id)
+);
+
 ALTER TABLE issue
     ADD CONSTRAINT fk_issue_author_id FOREIGN KEY (author_id) REFERENCES member (id);
 
@@ -112,3 +121,6 @@ ALTER TABLE issue_assignee
 
 ALTER TABLE issue_assignee
     ADD CONSTRAINT fk_issue_assignee_assignee_id FOREIGN KEY (assignee_id) REFERENCES member (id);
+
+ALTER TABLE refresh_token
+    ADD CONSTRAINT fk_refresh_token_member_id FOREIGN KEY (member_id) REFERENCES member (id);


### PR DESCRIPTION
* chore: jwt 의존성 추가 #57

* feat: JwtExceptionType 구현 #57

* feat: JwtRepository 구현 #57

- refresh_token 테이블을 추가하고 refreshToken을 저장하는 찾는 기능을 구현했습니다.

* feat: MemberRepository 구현 #57

- email로 회원을 찾는 기능을 구현했습니다.
- 회원을 저장하는 기능을 구현했습니다.

* feat: JwtService 구현 #57

- JwtProvider로 토큰을 생성하는 기능을 구현했습니다.
- 로그인과 회원가입 시 검증하고 토큰을 반환하는 기능을 구현했습니다.
- refreshToken을 검증하고 accessToken을 재발급하는 기능을 구현했습니다.

* feat: JwtController 구현 #57

- 회원가입, 로그인, 토큰 재발급 api를 구현했습니다.

* feat: JwtAuthorizationFilter 구현 #57

* feat: requestDto에 valid 추가 #57

* feat: GlobalExceptionHandler 구현 #57

* feat: jwt 로그아웃 기능 구현 #57

* refactor: jwt 로그아웃 기능 수정 #57

- claims에 넣어놨던 memberId를 이용해 로그아웃하도록 수정했습니다.

* refactor: repository에서 의존성 주입 방식 변경 #57

- Datasource 대신 NamedParameterJdbcTemplate을 주입받도록 수정했습니다.

* feat: jwt를 사용해 로그인, 로그아웃 기능 구현 #57

* test: 통합테스트 요청 시 토큰 삽입 #57

* test: MemberRepositoryTest에 findByEmail테스트 작성 #57

* refactor: HttpServletRequest을 Service에서 사용하지 않도록 수정 #57

* test: JwtIntegrationTest 작성 #57

---------

<!-- 피알 제목 예시입니다. -->
<!-- [BE]: 회원 가입 기능 추가 (#14) -->

### 구현 내용

<!-- 전체적인 구현 내용을 적어주세요 -->
<!-- 예시: 회원 가입 기능을 만들었습니다. -->

### 상세 내용

<!-- 구현 내용의 상세 내용을 적어주세요 -->
<!-- 예시: 
- 패스워드 암호화 저장
- 아이디 길이 검증
- 아이디 중복 검증
- 회원 가입 테스트 코드 작성
-->
