### PR TITLE
[BE]: 3주차 리뷰 반영 (#81) (#83)

### DIFF
--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/Comment.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/Comment.java
@@ -8,8 +8,8 @@ public class Comment {
 
     private final Long authorId;
     private final Long issueId;
-    private final String contents;
-    private final String file;
+    private String contents;
+    private String file;
 
     @Builder
     public Comment(Long authorId, Long issueId, String contents, String file) {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/Issue.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/Issue.java
@@ -10,7 +10,7 @@ public class Issue {
 
     private final Long id;
     private final Long authorId;
-    private final Long milestoneId;
+    private Long milestoneId;
     private final String title;
     private final String status;
     private final LocalDateTime createdAt;

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/controller/request/IssueCreateRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/controller/request/IssueCreateRequest.java
@@ -5,17 +5,19 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class IssueCreateRequest {
 
-    private final Long authorId;
-    private final String title;
-    private final String comment;
-    private final List<Long> assignees;
-    private final List<Long> labels;
-    private final Long milestone;
-    private final String file;
+    private Long authorId;
+    private String title;
+    private String comment;
+    private List<Long> assignees;
+    private List<Long> labels;
+    private Long milestone;
+    private String file;
 
     @Builder
     private IssueCreateRequest(Long authorId, String title, String comment, List<Long> assignees, List<Long> labels,

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/controller/request/IssueStatusRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/controller/request/IssueStatusRequest.java
@@ -6,13 +6,15 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class IssueStatusRequest {
 
     @JsonProperty("isOpen")
-    private final boolean open;
-    private final List<Long> issues;
+    private boolean open;
+    private List<Long> issues;
 
     @Builder
     private IssueStatusRequest(boolean open, List<Long> issues) {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/controller/request/IssueUpdateRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/controller/request/IssueUpdateRequest.java
@@ -5,14 +5,16 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class IssueUpdateRequest {
 
-    private final String title;
-    private final List<Long> assignees;
-    private final List<Long> labels;
-    private final Long milestone;
+    private String title;
+    private List<Long> assignees;
+    private List<Long> labels;
+    private Long milestone;
 
     @Builder
     private IssueUpdateRequest(String title, List<Long> assignees, List<Long> labels, Long milestone) {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/controller/response/ApiResponse.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/controller/response/ApiResponse.java
@@ -18,7 +18,7 @@ public class ApiResponse<T> {
         return new ApiResponse(status.value(), null);
     }
 
-    public static ApiResponse exception(HttpStatus status, String data) {
+    public static ApiResponse fail(HttpStatus status, String data) {
         return new ApiResponse<>(status.value(), data);
 
     }

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/IssueService.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/IssueService.java
@@ -87,8 +87,12 @@ public class IssueService {
         if (comment.isContentsExist()) {
             commentRepository.createComment(fileId, comment);
         }
-        memberRepository.addIssueAssignees(createdId, condition.getAssignees());
-        labelRepository.addIssueLabels(createdId, condition.getLabels());
+        if (condition.getAssignees() != null) {
+            memberRepository.addIssueAssignees(createdId, condition.getAssignees());
+        }
+        if (condition.getLabels() != null) {
+            labelRepository.addIssueLabels(createdId, condition.getLabels());
+        }
     }
 
     public void deleteIssue(Long issueId) {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/condition/IssueCreateCondition.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/condition/IssueCreateCondition.java
@@ -12,11 +12,11 @@ public class IssueCreateCondition {
 
     private final Long authorId;
     private final String title;
-    private final String comment;
-    private final List<Long> assignees;
-    private final List<Long> labels;
-    private final Long milestone;
-    private final String file;
+    private String comment;
+    private List<Long> assignees;
+    private List<Long> labels;
+    private Long milestone;
+    private String file;
 
     @Builder
     public IssueCreateCondition(Long authorId, String title, String comment, List<Long> assignees, List<Long> labels,

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/condition/IssueUpdateCondition.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/service/condition/IssueUpdateCondition.java
@@ -11,9 +11,9 @@ public class IssueUpdateCondition {
 
     private final Long issueId;
     private final String title;
-    private final List<Long> assignees;
-    private final List<Long> labels;
-    private final Long milestone;
+    private List<Long> assignees;
+    private List<Long> labels;
+    private Long milestone;
 
     @Builder
     public IssueUpdateCondition(Long issueId, String title, List<Long> assignees, List<Long> labels, Long milestone) {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/JwtAuthorizationFilter.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/JwtAuthorizationFilter.java
@@ -14,6 +14,8 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.util.PatternMatchUtils;
@@ -34,7 +36,7 @@ public class JwtAuthorizationFilter implements Filter {
 
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
 
-        if (httpServletRequest.getMethod().equals("OPTIONS")) {
+        if (httpServletRequest.getMethod().equals(HttpMethod.OPTIONS)) {
             return;
         }
         if (whiteListCheck(httpServletRequest.getRequestURI())) {
@@ -57,7 +59,7 @@ public class JwtAuthorizationFilter implements Filter {
     }
 
     private String getToken(HttpServletRequest request) {
-        String authorization = request.getHeader("Authorization");
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
         return authorization.substring(7).replace("\"","");
     }
 
@@ -66,7 +68,7 @@ public class JwtAuthorizationFilter implements Filter {
     }
 
     private boolean isContainToken(HttpServletRequest request) {
-        String authorization = request.getHeader("Authorization");
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
         return authorization != null && authorization.startsWith("Bearer ");
     }
 
@@ -83,7 +85,7 @@ public class JwtAuthorizationFilter implements Filter {
 
     private ApiResponse generateErrorApiResponse(RuntimeException e) {
         JwtExceptionType jwtExceptionType = JwtExceptionType.from(e);
-        return ApiResponse.exception(jwtExceptionType.getHttpstatus(), jwtExceptionType.getMessage());
+        return ApiResponse.fail(jwtExceptionType.getHttpstatus(), jwtExceptionType.getMessage());
     }
 
 }

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/AuthenticationController.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/AuthenticationController.java
@@ -3,7 +3,6 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.controller.response.ApiResponse;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request.LoginRequest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request.RefreshTokenRequest;
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request.SignUpRequest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.response.JwtResponse;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.service.JwtService;
 import javax.servlet.http.HttpServletRequest;
@@ -16,19 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-public class JwtController {
+public class AuthenticationController {
 
     private final JwtService jwtService;
 
     @PostMapping("/api/login")
     public JwtResponse login(@RequestBody @Valid LoginRequest request) {
         return JwtResponse.from(jwtService.login(LoginRequest.to(request)));
-    }
-
-    @PostMapping("/api/signup")
-    public ApiResponse signUp(@RequestBody @Valid SignUpRequest request) {
-        jwtService.signUp(SignUpRequest.to(request));
-        return ApiResponse.success(HttpStatus.OK);
     }
 
     @PostMapping("/api/auth/reissue")

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/request/LoginRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/request/LoginRequest.java
@@ -5,14 +5,16 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class LoginRequest {
 
     @Email
-    private final String email;
+    private String email;
     @NotBlank
-    private final String password;
+    private String password;
 
     @Builder
     public LoginRequest(String email, String password) {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/request/RefreshTokenRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/controller/request/RefreshTokenRequest.java
@@ -1,8 +1,10 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@NoArgsConstructor
 @Setter
 @Getter
 public class RefreshTokenRequest {
@@ -13,5 +15,4 @@ public class RefreshTokenRequest {
         this.refreshToken = refreshToken;
     }
 
-    public RefreshTokenRequest(){}
 }

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/repository/JwtRepository.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/repository/JwtRepository.java
@@ -2,6 +2,7 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.repository;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.Member;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.RowMapper;
@@ -14,16 +15,18 @@ public class JwtRepository {
 
     private final NamedParameterJdbcTemplate template;
 
-    public Member findByRefreshToken(String refreshToken) {
+    public Optional<Member> findByRefreshToken(String refreshToken) {
         String sql = "SELECT member.id, member.email, member.name, member.password, member.profile "
                 + "FROM member "
                 + "JOIN refresh_token "
                 + "ON member.id = refresh_token.member_id "
                 + "WHERE refresh_token.refresh_token = :refreshToken";
         try {
-            return template.queryForObject(sql, Map.of("refreshToken", refreshToken), memberRowMapper());
+            Member member = template.queryForObject(sql, Map.of("refreshToken", refreshToken),
+                    memberRowMapper());
+            return Optional.ofNullable(member);
         } catch (DataAccessException e) {
-            return null;
+            return Optional.empty();
         }
     }
 

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/Label.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/Label.java
@@ -8,7 +8,7 @@ public class Label {
 
     private final Long id;
     private final String name;
-    private final String description;
+    private String description;
     private final String backgroundColor;
     private final String textColor;
 

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/controller/request/LabelRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/controller/request/LabelRequest.java
@@ -4,14 +4,16 @@ import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.condition.L
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.label.service.condition.LabelUpdateCondition;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class LabelRequest {
 
-    private final String name;
-    private final String description;
-    private final String backgroundColor;
-    private final String textColor;
+    private String name;
+    private String description;
+    private String backgroundColor;
+    private String textColor;
 
     @Builder
     public LabelRequest(String name, String description, String backgroundColor, String textColor) {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/service/condition/LabelCreateCondition.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/service/condition/LabelCreateCondition.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public class LabelCreateCondition {
 
     private final String name;
-    private final String description;
+    private String description;
     private final String backgroundColor;
     private final String textColor;
 

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/service/condition/LabelUpdateCondition.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/service/condition/LabelUpdateCondition.java
@@ -9,7 +9,7 @@ public class LabelUpdateCondition {
 
     private final Long id;
     private final String name;
-    private final String description;
+    private String description;
     private final String backgroundColor;
     private final String textColor;
 

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/controller/MemberController.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/controller/MemberController.java
@@ -1,0 +1,24 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.member.controller;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.controller.response.ApiResponse;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.controller.request.SignUpRequest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.service.MemberService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/api/signup")
+    public ApiResponse signUp(@RequestBody @Valid SignUpRequest request) {
+        memberService.signUp(SignUpRequest.to(request));
+        return ApiResponse.success(HttpStatus.OK);
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/controller/request/SignUpRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/controller/request/SignUpRequest.java
@@ -1,20 +1,22 @@
-package codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request;
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.member.controller.request;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.service.condition.SignUpCondition;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class SignUpRequest {
 
     @Email
-    private final String email;
+    private String email;
     @NotBlank
-    private final String password;
+    private String password;
     @NotBlank
-    private final String profile;
+    private String profile;
 
     @Builder
     public SignUpRequest(String email, String password, String profile) {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/service/MemberService.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/member/service/MemberService.java
@@ -1,0 +1,29 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.member.service;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.service.condition.SignUpCondition;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.Member;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.repository.MemberRepository;
+import codesquad.kr.gyeonggidoidle.issuetracker.exception.MemberDuplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void signUp(SignUpCondition condition) {
+        String email = condition.getEmail();
+        if (existMember(memberRepository.findByEmail(email))) {
+            throw new MemberDuplicationException(email);
+        }
+        memberRepository.saveMember(SignUpCondition.to(condition));
+    }
+
+    private boolean existMember(Member member) {
+        return member != null;
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/Milestone.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/Milestone.java
@@ -11,7 +11,7 @@ public class Milestone {
     private final Long id;
     private final String name;
     private final LocalDate dueDate;
-    private final String description;
+    private String description;
     private final String status;
 
     @Builder

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/MilestoneController.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/MilestoneController.java
@@ -2,6 +2,7 @@ package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.controller;
 
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.controller.response.ApiResponse;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.controller.request.MilestoneRequest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.controller.request.MilestoneStatusRequest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.controller.response.MilestonePageResponse;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.MilestoneService;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +14,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -50,8 +50,8 @@ public class MilestoneController {
     }
 
     @PatchMapping("/api/milestones/{milestoneId}")
-    public ApiResponse updateStatus(@PathVariable Long milestoneId, @RequestParam("isOpen") boolean isOpen) {
-        milestoneService.updateStatus(milestoneId, isOpen);
+    public ApiResponse updateStatus(@PathVariable Long milestoneId, @RequestBody MilestoneStatusRequest request) {
+        milestoneService.updateStatus(milestoneId, request.isOpen());
         return ApiResponse.success(HttpStatus.OK);
     }
 }

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/request/MilestoneRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/request/MilestoneRequest.java
@@ -5,13 +5,15 @@ import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.service.conditi
 import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class MilestoneRequest {
 
-    private final String name;
-    private final String description;
-    private final LocalDate dueDate;
+    private String name;
+    private String description;
+    private LocalDate dueDate;
 
     @Builder
     public MilestoneRequest(String name, String description, LocalDate dueDate) {

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/request/MilestoneStatusRequest.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/controller/request/MilestoneStatusRequest.java
@@ -1,0 +1,17 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.controller.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class MilestoneStatusRequest {
+
+    @JsonProperty("isOpen")
+    private boolean open;
+
+    public MilestoneStatusRequest(boolean open) {
+        this.open = open;
+    }
+}

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/vo/MilestoneDetailsVO.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/vo/MilestoneDetailsVO.java
@@ -10,7 +10,7 @@ public class MilestoneDetailsVO {
 
     private final Long id;
     private final String name;
-    private final String description;
+    private String description;
     private final LocalDate dueDate;
     private final Integer openIssueCount;
     private final Integer closedIssuesCount;

--- a/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/codesquad/kr/gyeonggidoidle/issuetracker/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package codesquad.kr.gyeonggidoidle.issuetracker.exception;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.controller.response.ApiResponse;
 import io.jsonwebtoken.JwtException;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -11,17 +12,22 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ApiResponse handleException(Exception e) {
-        return ApiResponse.exception(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        return ApiResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(CustomException.class)
     public ApiResponse handleException(CustomException e) {
-        return ApiResponse.exception(e.getHttpStatus(), e.getMessage());
+        return ApiResponse.fail(e.getHttpStatus(), e.getMessage());
     }
 
     @ExceptionHandler(JwtException.class)
     public ApiResponse handleException(JwtException e) {
         JwtExceptionType jwtExceptionType = JwtExceptionType.from(e);
-        return ApiResponse.exception(jwtExceptionType.getHttpstatus(), jwtExceptionType.getMessage());
+        return ApiResponse.fail(jwtExceptionType.getHttpstatus(), jwtExceptionType.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse handleException(MethodArgumentNotValidException e) {
+        return ApiResponse.fail(HttpStatus.BAD_REQUEST, e.getMessage());
     }
 }

--- a/be/src/main/resources/schema.sql
+++ b/be/src/main/resources/schema.sql
@@ -23,7 +23,7 @@ CREATE TABLE milestone
     id          bigint AUTO_INCREMENT,
     name        varchar(50) NOT NULL,
     due_date    date        NOT NULL,
-    description varchar(255),
+    description varchar(2000),
     is_open     boolean     NOT NULL default TRUE,
     is_deleted  boolean     NOT NULL default FALSE,
     PRIMARY KEY (id)

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/integration/IssueIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/issue/integration/IssueIntegrationTest.java
@@ -1,5 +1,14 @@
 package codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.integration;
 
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.IntegrationTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.controller.request.IssueCreateRequest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.issue.controller.request.IssueStatusRequest;
@@ -8,20 +17,14 @@ import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.Jwt;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.JwtProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-
-import java.util.List;
-import java.util.Map;
-
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @IntegrationTest
 class IssueIntegrationTest {
@@ -38,8 +41,10 @@ class IssueIntegrationTest {
     @DisplayName("열린 이슈의 모든 정보를 다 가지고 온다.")
     @Test
     void getOpenIssues() throws Exception {
-        //when
+        // given
         Jwt jwt = makeToken();
+
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/issues/open")
                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
@@ -59,8 +64,10 @@ class IssueIntegrationTest {
     @DisplayName("닫힌 이슈의 모든 정보를 다 가지고 온다.")
     @Test
     void getClosedIssues() throws Exception {
-        //when
+        // given
         Jwt jwt = makeToken();
+
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/issues/closed")
                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
@@ -80,8 +87,10 @@ class IssueIntegrationTest {
     @DisplayName("메인 화면의 필터 목록을 가지고 온다.")
     @Test
     void getFilters() throws Exception {
-        //when
+        // given
         Jwt jwt = makeToken();
+
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/filters")
                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
@@ -100,8 +109,10 @@ class IssueIntegrationTest {
     @DisplayName("이슈 화면의 필터 목록을 가지고 온다.")
     @Test
     void getFiltersByIssue() throws Exception {
-        //when
+        // given
         Jwt jwt = makeToken();
+
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/issues")
                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
@@ -123,18 +134,20 @@ class IssueIntegrationTest {
     @DisplayName("선택한 여러 개의 이슈 상태를 변경한다.")
     @Test
     void testUpdateIssuesStatusIntegrationTest() throws Exception {
-
+        // given
         IssueStatusRequest request = IssueStatusRequest.builder()
                 .open(false)
                 .issues(List.of(4L, 5L))
                 .build();
-
         Jwt jwt = makeToken();
+
+        // when
         ResultActions resultActions = mockMvc.perform(patch("/api/issues")
                 .header("Authorization", "Bearer " + jwt.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(request)));
 
+        // then
         resultActions.andExpect(status().isOk())
                 .andDo(print());
     }
@@ -142,10 +155,14 @@ class IssueIntegrationTest {
     @DisplayName("선택한 이슈를 삭제한다.")
     @Test
     void testDeleteIssue() throws Exception {
+        // given
         Jwt jwt = makeToken();
+
+        // when
         ResultActions resultActions = mockMvc.perform(delete("/api/issues/1")
                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
+        // then
         resultActions.andExpect(status().isOk())
                 .andDo(print());
     }
@@ -153,16 +170,18 @@ class IssueIntegrationTest {
     @DisplayName("선택한 하나의 이슈 상태를 변경한다.")
     @Test
     void testUpdateIssueStatus() throws Exception {
+        // given
         IssueStatusRequest request = IssueStatusRequest.builder()
                 .open(false)
                 .build();
-
         Jwt jwt = makeToken();
+
+        // when
         ResultActions resultActions = mockMvc.perform(patch("/api/issues/2")
                 .header("Authorization", "Bearer " + jwt.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(request)));
-
+        // then
         resultActions.andExpect(status().isOk())
                 .andDo(print());
     }
@@ -170,6 +189,7 @@ class IssueIntegrationTest {
     @DisplayName("이슈를 생성한다.")
     @Test
     void testCreate() throws Exception {
+        // given
         IssueCreateRequest request = IssueCreateRequest.builder()
                 .title("제목")
                 .authorId(1L)
@@ -177,13 +197,15 @@ class IssueIntegrationTest {
                 .labels(List.of(2L))
                 .milestone(1L)
                 .build();
-
         Jwt jwt = makeToken();
+
+        // when
         ResultActions resultActions = mockMvc.perform(post("/api/issues")
                 .header("Authorization", "Bearer " + jwt.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(request)));
 
+        // then
         resultActions.andExpect(status().isOk())
                 .andDo(print());
     }
@@ -198,9 +220,9 @@ class IssueIntegrationTest {
                 .labels(List.of(2L))
                 .milestone(1L)
                 .build();
+        Jwt jwt = makeToken();
 
         // when
-        Jwt jwt = makeToken();
         ResultActions resultActions = mockMvc.perform(put("/api/issues/1")
                 .header("Authorization", "Bearer " + jwt.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON)

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/integration/JwtIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/jwt/integration/JwtIntegrationTest.java
@@ -7,15 +7,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import codesquad.kr.gyeonggidoidle.issuetracker.annotation.IntegrationTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request.LoginRequest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request.RefreshTokenRequest;
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.controller.request.SignUpRequest;
-import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.Jwt;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.JwtProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Map;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -35,17 +31,19 @@ public class JwtIntegrationTest {
 
     @DisplayName("이메일과 비밀번호를 받아 JwtResponse를 반환한다.")
     @Test
-    @Order(1)
     void login() throws Exception {
+        // given
         LoginRequest request = LoginRequest.builder()
                 .email("joy@codesquad.kr")
                 .password("1q2w3e4r!")
                 .build();
 
+        // when
         ResultActions resultActions = mockMvc.perform(post("/api/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(request)));
 
+        // then
         resultActions
                 .andExpect(status().isOk())
                 .andExpectAll(
@@ -55,35 +53,31 @@ public class JwtIntegrationTest {
                 );
     }
 
-    @DisplayName("이메일, 비밀번호, 프로필사진을 받아 회원가입을 한다.")
-    @Test
-    @Order(2)
-    void signUp() throws Exception {
-        SignUpRequest request = SignUpRequest.builder()
-                .email("test@test.com")
-                .password("!test1234")
-                .profile("profile1234")
-                .build();
-
-        ResultActions resultActions = mockMvc.perform(post("/api/signup")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(request)));
-
-        resultActions
-                .andExpect(status().isOk());
-    }
-
     @DisplayName("refreshToken을 받아서 새로운 accessToken이 담긴 JwtResponse를 반환한다.")
     @Test
-    @Order(3)
-    @Disabled
     void reissueAccessToken() throws Exception {
-        Jwt jwt = makeToken();
-        RefreshTokenRequest request = new RefreshTokenRequest(jwt.getRefreshToken());
+        // given
+        LoginRequest loginRequest = LoginRequest.builder()
+                .email("joy@codesquad.kr")
+                .password("1q2w3e4r!")
+                .build();
+
+        ResultActions loginResult = mockMvc.perform(post("/api/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(loginRequest)));
+
+        String jsonResponse = loginResult.andReturn().getResponse().getContentAsString();
+        JsonNode jsonNode = new ObjectMapper().readTree(jsonResponse);
+        String refreshToken = jsonNode.get("refreshToken").asText();
+
+        RefreshTokenRequest request = new RefreshTokenRequest(refreshToken);
+
+        // when
         ResultActions resultActions = mockMvc.perform(post("/api/auth/reissue")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(request)));
 
+        // then
         resultActions
                 .andExpect(status().isOk())
                 .andExpectAll(
@@ -95,20 +89,31 @@ public class JwtIntegrationTest {
 
     @DisplayName("HttpServletRequest에 담긴 claim의 memberId를 가지고 refreshToken을 삭제한다.")
     @Test
-    @Order(4)
     void logout() throws Exception {
-        Jwt jwt = makeToken();
-        ResultActions resultActions = mockMvc.perform(post("/api/logout")
-                .header("Authorization", "Bearer " + jwt.getAccessToken()));
+        // given
+        LoginRequest loginRequest = LoginRequest.builder()
+                .email("joy@codesquad.kr")
+                .password("1q2w3e4r!")
+                .build();
 
-        resultActions.andExpect(status().isOk());
+        ResultActions loginResult = mockMvc.perform(post("/api/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(loginRequest)));
+
+        String jsonResponse = loginResult.andReturn().getResponse().getContentAsString();
+        JsonNode jsonNode = new ObjectMapper().readTree(jsonResponse);
+        String accessToken = jsonNode.get("accessToken").asText();
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/api/logout")
+                .header("Authorization", "Bearer " + accessToken));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(200));
     }
 
     private <T> String toJson(T data) throws JsonProcessingException {
         return objectMapper.writeValueAsString(data);
-    }
-
-    private Jwt makeToken() {
-        return jwtProvider.createJwt(Map.of("memberId",2L));
     }
 }

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/integration/LabelIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/integration/LabelIntegrationTest.java
@@ -37,8 +37,10 @@ class LabelIntegrationTest {
     @DisplayName("라벨의 모드 정보를 가지고 온다.")
     @Test
     void getLabels() throws Exception {
-        //when
+        // given
         Jwt jwt = makeToken();
+
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/labels")
                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
@@ -63,9 +65,9 @@ class LabelIntegrationTest {
                 .backgroundColor("##")
                 .textColor("#")
                 .build();
+        Jwt jwt = makeToken();
 
         // when
-        Jwt jwt = makeToken();
         ResultActions resultActions = mockMvc.perform(post("/api/labels")
                 .header("Authorization", "Bearer " + jwt.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -80,8 +82,10 @@ class LabelIntegrationTest {
     @DisplayName("하나의 라벨 정보를 가져온다.")
     @Test
     void read() throws Exception {
-        // when
+        // given
         Jwt jwt = makeToken();
+
+        // when
         ResultActions resultActions = mockMvc.perform(get("/api/labels/1")
                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
@@ -105,9 +109,9 @@ class LabelIntegrationTest {
                 .backgroundColor("##")
                 .textColor("#")
                 .build();
+        Jwt jwt = makeToken();
 
         // when
-        Jwt jwt = makeToken();
         ResultActions resultActions = mockMvc.perform(patch("/api/labels/1")
                 .header("Authorization", "Bearer " + jwt.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -122,8 +126,10 @@ class LabelIntegrationTest {
     @DisplayName("라벨 아이디를 받아 라벨을 삭제한다.")
     @Test
     void delete() throws Exception {
-        // when
+        // given
         Jwt jwt = makeToken();
+
+        // when
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.delete("/api/labels/3")
                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/label/repository/LabelRepositoryTest.java
@@ -53,7 +53,7 @@ class LabelRepositoryTest {
         });
     }
 
-    @DisplayName("Label을 받아서 db에 저장하고 성공하면 true를 반환한다.")
+    @DisplayName("라벨 저장에 성공한다.")
     @Test
     void save() {
         // given
@@ -84,7 +84,7 @@ class LabelRepositoryTest {
         });
     }
 
-    @DisplayName("라벨 내용을 수정하고 성공하면 true를 반환한다.")
+    @DisplayName("라벨 내용 수정을 성공한다.")
     @Test
     void update() {
         // given
@@ -101,7 +101,7 @@ class LabelRepositoryTest {
         assertThat(actual).isTrue();
     }
 
-    @DisplayName("라벨 아이디를 받아 is_deleted를 true로 바꾸고 성공하면 true를 반환한다")
+    @DisplayName("라벨 삭제에 성공한다.")
     @Test
     void delete() {
         // when

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/integration/MilestoneIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/integration/MilestoneIntegrationTest.java
@@ -11,6 +11,7 @@ import codesquad.kr.gyeonggidoidle.issuetracker.annotation.IntegrationTest;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.Jwt;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.jwt.entity.JwtProvider;
 import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.controller.request.MilestoneRequest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.milestone.controller.request.MilestoneStatusRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
@@ -36,8 +37,10 @@ class MilestoneIntegrationTest {
     @DisplayName("열린 마일스톤의 모드 정보를 가지고 온다.")
     @Test
     void getOpenMilestones() throws Exception {
-        //when
+        // given
         Jwt jwt = makeToken();
+
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/milestones/open")
                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
@@ -56,8 +59,10 @@ class MilestoneIntegrationTest {
     @DisplayName("닫힌 마일스톤의 모드 정보를 가지고 온다.")
     @Test
     void readClosedMilestones() throws Exception {
-        //when
+        // given
         Jwt jwt = makeToken();
+
+        //when
         ResultActions resultActions = mockMvc.perform(get("/api/milestones/closed")
                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
@@ -82,9 +87,9 @@ class MilestoneIntegrationTest {
                 .description("설명")
                 .dueDate(LocalDate.now())
                 .build();
+        Jwt jwt = makeToken();
 
         // when
-        Jwt jwt = makeToken();
         ResultActions resultActions = mockMvc.perform(post("/api/milestones")
                 .header("Authorization", "Bearer " + jwt.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -105,9 +110,9 @@ class MilestoneIntegrationTest {
                 .description("설명")
                 .dueDate(LocalDate.now())
                 .build();
+        Jwt jwt = makeToken();
 
         // when
-        Jwt jwt = makeToken();
         ResultActions resultActions = mockMvc.perform(put("/api/milestones/1")
                 .header("Authorization", "Bearer " + jwt.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -122,8 +127,10 @@ class MilestoneIntegrationTest {
     @DisplayName("마일스톤 아이디를 받아 마일스톤을 삭제한다.")
     @Test
     void delete() throws Exception {
-        // when
+        // given
         Jwt jwt = makeToken();
+
+        // when
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.delete("/api/milestones/3")
                 .header("Authorization", "Bearer " + jwt.getAccessToken()));
 
@@ -136,10 +143,15 @@ class MilestoneIntegrationTest {
     @DisplayName("마일스톤 아이디와 변경 할 상태를 받아 마일스톤의 상태를 변경한다.")
     @Test
     void updateStatus() throws Exception {
-        // when
+        // given
+        MilestoneStatusRequest request = new MilestoneStatusRequest(false);
         Jwt jwt = makeToken();
-        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch("/api/milestones/3?isOpen=false")
-                .header("Authorization", "Bearer " + jwt.getAccessToken()));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch("/api/milestones/3")
+                .header("Authorization", "Bearer " + jwt.getAccessToken())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)));
 
         // then
         resultActions.andExpect(status().isOk())

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/MilestoneRepositoryTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/domain/milestone/repository/MilestoneRepositoryTest.java
@@ -69,7 +69,7 @@ class MilestoneRepositoryTest {
         assertThat(actual).isTrue();
     }
 
-    @DisplayName("라벨 내용을 수정하고 성공하면 true를 반환한다.")
+    @DisplayName("라벨 내용 수정을 성공한다.")
     @Test
     void update() {
         // given
@@ -85,7 +85,7 @@ class MilestoneRepositoryTest {
         assertThat(actual).isTrue();
     }
 
-    @DisplayName("마일스톤 아이디를 받아 is_deleted를 true로 바꾸고 성공하면 true를 반환한다")
+    @DisplayName("마일스톤 삭제에 성공한다.")
     @Test
     void delete() {
         // when
@@ -94,7 +94,7 @@ class MilestoneRepositoryTest {
         assertThat(actual).isTrue();
     }
 
-    @DisplayName("마일스톤 아이디를 받아 is_open을 바꾸고 성공하면 true를 반환한다")
+    @DisplayName("마일스톤 상태변경을 성공한다.")
     @Test
     void updateStatus() {
         // when

--- a/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/member/integration/MemberIntegrationTest.java
+++ b/be/src/test/java/codesquad/kr/gyeonggidoidle/issuetracker/member/integration/MemberIntegrationTest.java
@@ -1,0 +1,49 @@
+package codesquad.kr.gyeonggidoidle.issuetracker.member.integration;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import codesquad.kr.gyeonggidoidle.issuetracker.annotation.IntegrationTest;
+import codesquad.kr.gyeonggidoidle.issuetracker.domain.member.controller.request.SignUpRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@IntegrationTest
+public class MemberIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @DisplayName("이메일, 비밀번호, 프로필사진을 받아 회원가입을 한다.")
+    @Test
+    void signUp() throws Exception {
+        // given
+        SignUpRequest request = SignUpRequest.builder()
+                .email("test@test.com")
+                .password("!test1234")
+                .profile("profile1234")
+                .build();
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/api/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)));
+
+        // then
+        resultActions
+                .andExpect(status().isOk());
+    }
+
+    private <T> String toJson(T data) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(data);
+    }
+}


### PR DESCRIPTION
* refactor: requestDto기본 생성자 추가, final 제거 #81

* refactor: 마일스톤 상태 수정 시 @RequestBody로 변경 #81

* refactor: milestone의 description varchar 수정  #81

* refactor: 통합테스트의 makeJwt()를 given절로 이동  #81

* refactor: null이 들어올 수 있는 변수에 final 삭제  #81

* refactor: JwtController를 MemberController와 AuthenticationController로 분리 #81

* refactor: JwtAuthorizationFilter의 매직스트링 제거 #81

* refactor: RepositoryTest @DisplayName 수정 #81

* refactor: JwtIntegrationTest 토큰 재발급, 로그아웃 테스트에 로그인 로직 추가 #81

* refactor: JwtIntegrationTest 로그아웃 상태코드 검증 추가 #81

* refactor: MethodArgumentNotValidException 예외처리 추가 #81

* refactor: 반환타입을 Optional로 수정 #81

<!-- 피알 제목 예시입니다. -->
<!-- [BE]: 회원 가입 기능 추가 (#14) -->

### 구현 내용

<!-- 전체적인 구현 내용을 적어주세요 -->
<!-- 예시: 회원 가입 기능을 만들었습니다. -->

### 상세 내용

<!-- 구현 내용의 상세 내용을 적어주세요 -->
<!-- 예시: 
- 패스워드 암호화 저장
- 아이디 길이 검증
- 아이디 중복 검증
- 회원 가입 테스트 코드 작성
-->
